### PR TITLE
Integration test cases for:

### DIFF
--- a/tests/AuthorizeNetTD_Test.php
+++ b/tests/AuthorizeNetTD_Test.php
@@ -46,7 +46,37 @@ class AuthorizeNetTD_Test extends PHPUnit_Framework_TestCase
         $response = $request->getTransactionList($batch_id);
         $this->assertTrue($response->isOk());
     }
-    
+
+    public function testGetTransactionListReturnedItems()
+    {
+        $request = new AuthorizeNetTD;
+        $batchId = 0; // Set your $batchId here
+        $response = $request->getTransactionList($batchId);
+        $this->assertTrue($response->isOk());
+        $transactions = $response->xpath("transactions/transaction");
+        $transId = $transactions[0]->transId;
+
+        $details = new AuthorizeNetTD;
+        $response = $details->getTransactionDetails($transId);
+        $this->assertTrue($response->isOk());
+        $transaction = $response->xml->transaction[0];
+        $this->assertFalse(empty($transaction->returnedItems));
+
+    }
+
+
+    public function testGetTransactionListSubscription()
+    {
+        $transId = 0; // Set your $transId here
+
+        $details = new AuthorizeNetTD;
+        $response = $details->getTransactionDetails($transId);
+        $this->assertTrue($response->isOk());
+        $transaction = $response->xml->transaction[0];
+
+        $this->assertFalse(empty($transaction->subscription));
+    }
+
     public function testGetTransactionDetails()
     {
         $sale = new AuthorizeNetAIM;
@@ -65,7 +95,29 @@ class AuthorizeNetTD_Test extends PHPUnit_Framework_TestCase
         $this->assertEquals("Visa", (string)$response->xml->transaction->payment->creditCard->cardType);
         
     }
-    
+
+
+    public function testGetTransactionDetailsWithSolutionId()
+    {
+        $sale = new AuthorizeNetAIM;
+        $amount = rand(1, 100);
+        $sale->setCustomField('x_solution_id', 'A1000002');
+        $response = $sale->authorizeAndCapture($amount, '4012888818888', '04/17');
+        $this->assertTrue($response->approved);
+
+        $transId = $response->transaction_id;
+
+        $request = new AuthorizeNetTD;
+        $response = $request->getTransactionDetails($transId);
+        $this->assertTrue($response->isOk());
+
+        $this->assertEquals($transId, (string)$response->xml->transaction->transId);
+        $this->assertEquals($amount, (string)$response->xml->transaction->authAmount);
+        $this->assertEquals("Visa", (string)$response->xml->transaction->payment->creditCard->cardType);
+        $this->assertEquals("A1000002", (string)$response->xml->transaction->solution->id);
+    }
+
+
     public function testGetUnsettledTransactionList()
     {
         $sale = new AuthorizeNetAIM;
@@ -78,7 +130,23 @@ class AuthorizeNetTD_Test extends PHPUnit_Framework_TestCase
         $this->assertTrue($response->isOk());
         $this->assertTrue($response->xml->transactions->count() >= 1);
     }
-    
+
+    public function testGetUnsettledTransactionListHasNoReturnedItems()
+    {
+        $request = new AuthorizeNetTD;
+        $response = $request->getUnsettledTransactionList();
+        $this->assertTrue($response->isOk());
+        $this->assertTrue($response->xml->transactions->count() >= 1);
+
+        foreach($response->xml->transactions->transaction as $transaction)
+        {
+            if($transaction->hasReturnedItems)
+            {
+                $this->assertEquals("false", $transaction->hasReturnedItems);
+            }
+        }
+    }
+
     public function testGetBatchStatistics()
     {
         $request = new AuthorizeNetTD;


### PR DESCRIPTION
• Support for Subscription Info in Reporting API
• Support for ReturnedItems in Reporting API
• Support for SolutionID in Reporting API

There is no need in SDK code change since PHP SDK structure is flexible with
API changes at backend.
