### PR TITLE
Reverse VERIFY_PEER exploit Commit

### DIFF
--- a/lib/shared/AuthorizeNetRequest.php
+++ b/lib/shared/AuthorizeNetRequest.php
@@ -94,10 +94,10 @@ abstract class AuthorizeNetRequest
         if ($this->VERIFY_PEER) {
             curl_setopt($curl_request, CURLOPT_CAINFO, dirname(dirname(__FILE__)) . '/ssl/cert.pem');
         } else {
-			if ($this->_log_file) {
-				file_put_contents($this->_log_file, "----Request----\nInvalid SSL option\n", FILE_APPEND);
-			}
-			return false;
+            curl_setopt($curl_request, CURLOPT_SSL_VERIFYPEER, false);
+            if ($this->_log_file) {
+                file_put_contents($this->_log_file, "----Request----\nUnsafe SSL option\n", FILE_APPEND);
+            }
         }
         
         if (preg_match('/xml/',$post_url)) {


### PR DESCRIPTION
I don't think it made any sense to merge this commit
https://github.com/AuthorizeNet/sdk-php/commit/45b647b3778d14cd761003342c25e438aa2bed06

You have a setting, that if you set it to false, then it just returns nothing. I am using this in a test environment and don't want to setup SSL for the server, so I should be able to turn off VERIFY_PEER at my own risk. Do not make the code hand hold people and prevent them from having a built in option for the curl extension.

Thanks.
