### PR TITLE
Update autoload.php

### DIFF
--- a/autoload.php
+++ b/autoload.php
@@ -14,7 +14,5 @@ spl_autoload_register(function($className) {
 
     if (isset($classMap[$className])) {
         include $classMap[$className];
-    } else {
-        echo 'Class not loaded: ' . $className;
     }
 });


### PR DESCRIPTION
Per [the docs](http://php.net/manual/en/function.spl-autoload-register.php) if there are multiple autoload functions, spl_autoload_register()  creates a queue of autoload functions, and runs through each of them in the order they are defined.

Hence, under those circumstances, not finding a particular class via this autoloader is to be expected. The `echo` output isn't a good idea as it is probably always undesired and it doesn't accomplish anything really. It can result in a lot of undesired output when combined with multiple autoloaders.