### PR TITLE
Fixed Community Issue - Error when Zero CIM profiles

### DIFF
--- a/lib/AuthorizeNetCIM.php
+++ b/lib/AuthorizeNetCIM.php
@@ -488,7 +488,10 @@ class AuthorizeNetCIM_Response extends AuthorizeNetXMLResponse
     public function getCustomerProfileIds()
     {
         $ids = (array)$this->xml->ids;
-        return $ids["numericString"];
+        if(!empty($ids))
+            return $ids["numericString"];
+        else
+            return $ids;
     }
     
     /**
@@ -497,7 +500,10 @@ class AuthorizeNetCIM_Response extends AuthorizeNetXMLResponse
     public function getCustomerPaymentProfileIds()
     {
         $ids = (array)$this->xml->customerPaymentProfileIdList;
-        return $ids["numericString"];
+        if(!empty($ids))
+            return $ids["numericString"];
+        else
+            return $ids;
     }
     
     /**
@@ -506,7 +512,10 @@ class AuthorizeNetCIM_Response extends AuthorizeNetXMLResponse
     public function getCustomerShippingAddressIds()
     {
         $ids = (array)$this->xml->customerShippingAddressIdList;
-        return $ids["numericString"];
+        if(!empty($ids))
+            return $ids["numericString"];
+        else
+            return $ids;
     }
     
     /**


### PR DESCRIPTION
Issue: https://github.com/AuthorizeNet/sdk-php/issues/45

Reproduced the issue by creating a sandbox account with zero customer profiles.
Error for getCustomerProfileIds() :
Notice: Undefined index: numericString in C:\..local_path...\authorizenet\authorizenet\lib\AuthorizeNetCIM.php on line 491

Fixed the issue by adding a check for empty array.