### PR TITLE
Changes to make the sdk works with custom autoloader script and PHP 7.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,14 @@
 language: php
 
 php:
+    - 5.6
     - 7.0
     
 sudo: false
 
 before_script:
     - pecl install xmldiff
-    - composer install --prefer-dist --dev
+    - composer install --prefer-dist --ignore-platform-reqs
     - chmod +x ./test-sample-codes.sh
     - git submodule update --recursive
     

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ require 'vendor/autoload.php';
 ```
 *Note: you'll need a composer.json file with the following require section and to run
 `composer update`.*
+
 ```json
 {
   "require": {
@@ -50,6 +51,15 @@ require 'vendor/autoload.php';
 Alternatively, we provide a custom `SPL` autoloader:
 ```php
 require 'path/to/anet_php_sdk/autoload.php';
+```
+
+**Issue with PHP 7:** *You may get below error when run the composer update with PHP 7. To get rid of this error, use `composer update --ignore-platform-reqs`*
+```php
+Problem 1
+    - Installation request for authorizenet/authorizenet 1.8.6.2 -> satisfiable
+by authorizenet/authorizenet[1.8.6.2].
+    - authorizenet/authorizenet 1.8.6.2 requires php ~5.3 -> your PHP version (7
+.0.3RC1) or value of "config.platform.php" in composer.json does not satisfy that requirement.
 ```
 
 ## Authentication
@@ -139,6 +149,11 @@ else
 	echo  "Charge Credit card Null response returned";
 }
 ```
+### Setting Production Environment  
+Replace the environment constant in the execute method.  For example, in the method above:
+```php
+$response = $controller->executeWithApiResponse( \net\authorize\api\constants\ANetEnvironment::PRODUCTION);
+```  
 
 ## Logging
 

--- a/classmap.php
+++ b/classmap.php
@@ -182,6 +182,9 @@ return array(
     'PhpOption\None' => $vendorDir . '/phpoption/phpoption/src/PhpOption/None.php',
     'PhpOption\Option' => $vendorDir . '/phpoption/phpoption/src/PhpOption/Option.php',
     'PhpOption\Some' => $vendorDir . '/phpoption/phpoption/src/PhpOption/Some.php',
+    'Symfony\Component\Yaml\Yaml' => $vendorDir . '/Symfony/Yaml/Yaml.php',
+    'Symfony\Component\Yaml\Parser' => $vendorDir . '/Symfony/Yaml/Parser.php',
+    'Symfony\Component\Yaml\Inline' => $vendorDir . '/Symfony/Yaml/Inline.php',
 
     'AuthorizeNetAIM'            => $libDir    . 'AuthorizeNetAIM.php',
     'AuthorizeNetAIM_Response'   => $libDir    . 'AuthorizeNetAIM.php',


### PR DESCRIPTION
classmap.php
============
Added Yaml class mapping references to make custom autoloader to work.
Ref : AuthorizeNet#86
README.md
=========
Added an argument to composer update command for composer to work with PHP 7
Ref : AuthorizeNet#78
.travis.yml
===========
Added an argument to composer install command to make sure the sdk works with PHP 7