### PR TITLE
Adding optional param to include currency code in getFingerprint

### DIFF
--- a/lib/AuthorizeNetSIM.php
+++ b/lib/AuthorizeNetSIM.php
@@ -197,22 +197,23 @@ class AuthorizeNetSIM_Form
     /**
      * Generates a fingerprint needed for a hosted order form or DPM.
      *
-     * @param string $api_login_id    Login ID.
-     * @param string $transaction_key API key.
-     * @param string $amount          Amount of transaction.
-     * @param string $fp_sequence     An invoice number or random number.
-     * @param string $fp_timestamp    Timestamp.
+     * @param string $api_login_id      Login ID.
+     * @param string $transaction_key   API key.
+     * @param string $amount            Amount of transaction.
+     * @param string $fp_sequence       An invoice number or random number.
+     * @param string $fp_timestamp      Timestamp.
+     * @param string $fp_currency_code  Currency Code
      *
      * @return string The fingerprint.
      */
-    public static function getFingerprint($api_login_id, $transaction_key, $amount, $fp_sequence, $fp_timestamp)
+    public static function getFingerprint($api_login_id, $transaction_key, $amount, $fp_sequence, $fp_timestamp, $fp_currency_code = '')
     {
         $api_login_id = ($api_login_id ? $api_login_id : (defined('AUTHORIZENET_API_LOGIN_ID') ? AUTHORIZENET_API_LOGIN_ID : ""));
         $transaction_key = ($transaction_key ? $transaction_key : (defined('AUTHORIZENET_TRANSACTION_KEY') ? AUTHORIZENET_TRANSACTION_KEY : ""));
         if (function_exists('hash_hmac')) {
-            return hash_hmac("md5", $api_login_id . "^" . $fp_sequence . "^" . $fp_timestamp . "^" . $amount . "^", $transaction_key); 
+            return hash_hmac("md5", $api_login_id . "^" . $fp_sequence . "^" . $fp_timestamp . "^" . $amount . "^" . $fp_currency_code, $transaction_key);
         }
-        return bin2hex(mhash(MHASH_MD5, $api_login_id . "^" . $fp_sequence . "^" . $fp_timestamp . "^" . $amount . "^", $transaction_key));
+        return bin2hex(mhash(MHASH_MD5, $api_login_id . "^" . $fp_sequence . "^" . $fp_timestamp . "^" . $amount . "^" . $fp_currency_code, $transaction_key));
     }
     
 }


### PR DESCRIPTION
Resolves #130 

Documentation about passing currency code in the fingerprint: https://support.authorize.net/authkb/index?page=content&id=A569
> If you are attempting to pass the field x_currency_code with your payment form request, you must include this field in your fingerprint hash generation.
> 
> When you generate the fingerprint script, you must use the Transaction Key to hash an input string of the following fields, in this exact order, delimited by the caret (^) character:
> 
> x_login
> x_fp_sequence
> x_fp_timestamp
> x_amount
> x_currency_code (optional)
> If you use x_currency_code then the input string would resemble this example:
> 
> APIl0gin1D^Sequence123^1457632735^19.99^USD
> 
> Alternately, you may stop passing x_currency_code and use your account's default currency. In this case you would drop the currency code from the input string, but not the caret before it:
> 
> APIl0gin1D^Sequence123^1457632735^19.99^