### PR TITLE
Additional functions for AuthorizeNetCIM and AuthorizeNetXMLResponse

### DIFF
--- a/lib/AuthorizeNetCIM.php
+++ b/lib/AuthorizeNetCIM.php
@@ -490,6 +490,18 @@ class AuthorizeNetCIM_Response extends AuthorizeNetXMLResponse
         $ids = (array)$this->xml->ids;
         return $ids["numericString"];
     }
+	
+	/**
+     * @return array
+     */
+    public function getCustomerProfile(){
+        return array(
+			'merchantCustomerId' => (int)$this->xml->profile->merchantCustomerId,
+			'customerProfileId' => (int)$this->xml->profile->customerProfileId,
+			'email' => (string)$this->xml->profile->email,
+			'description' => (string)$this->xml->profile->description,
+		);
+    }
     
     /**
      * @return array

--- a/lib/shared/AuthorizeNetXMLResponse.php
+++ b/lib/shared/AuthorizeNetXMLResponse.php
@@ -105,6 +105,13 @@ class AuthorizeNetXMLResponse
     {
         return $this->_getElementContents("text");
     }
+	
+	/**
+     * @return dynamic
+     */
+	 public function data(){
+		return json_decode(json_encode($this->xml));
+	 }
     
     /**
      * Grabs the contents of a unique element.


### PR DESCRIPTION
- `AuthorizeNetCIM::getCustomerProfile()`
  - Get customer profile as an array from the response XML
- `AuthorizeNetXMLResponse::data()`
  - Allows access to the actual response data. Right now there is no way to get the response XML.
