### PR TITLE
Allow setLogLevel. Added dependency and unit testing updates

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,6 +11,7 @@
         "ext-json": "*",
         "ext-simplexml": "*",
         "ext-xmlwriter": "*",
+        "goetas/xsd2php": "^2.0", 
         "goetas-webservices/xsd2php-runtime":"^0.2",
         "goetas-webservices/xsd-reader": "^0.1",
         "jms/serializer": "serializer-master-dev as 1.0"

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,8 @@
         "goetas/xsd2php": "^2.0", 
         "goetas-webservices/xsd2php-runtime":"^0.2",
         "goetas-webservices/xsd-reader": "^0.1",
-        "jms/serializer": "serializer-master-dev as 1.0"
+        "jms/serializer": "serializer-master-dev as 1.0",
+        "symfony/yaml": "^3.1"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.0",

--- a/lib/AuthorizeNetAIM.php
+++ b/lib/AuthorizeNetAIM.php
@@ -475,7 +475,7 @@ class AuthorizeNetAIM_Response extends AuthorizeNetResponse
             
             // Set custom fields
             if ($count = count($custom_fields)) {
-                $custom_fields_response = array_slice($this->_response_array, -$count, $count);
+                $custom_fields_response = array_slice($this->_response_array, -$count-1, $count);
                 $i = 0;
                 foreach ($custom_fields as $key => $value) {
                     $this->$key = $custom_fields_response[$i];

--- a/lib/net/authorize/util/Log.php
+++ b/lib/net/authorize/util/Log.php
@@ -334,7 +334,7 @@ class Log
 
     /**
      * @param string $logLevel
-       possible values = ANET_LOG_DEBUG, ANET_LOG_INFO, ANET_LOG_WARN, ANET_LOG_ERROR
+     * possible values = ANET_LOG_DEBUG, ANET_LOG_INFO, ANET_LOG_WARN, ANET_LOG_ERROR
      */
     public function setLogLevel($logLevel){
         $this->logLevel = $logLevel;

--- a/lib/net/authorize/util/Log.php
+++ b/lib/net/authorize/util/Log.php
@@ -30,6 +30,7 @@ class Log
 {
     private $sensitiveXmlTags = NULL;
     private $logFile = '';
+    private $logLevel = ANET_LOG_LEVEL;
 	
 	/**
 	* Takes a regex pattern (string) as argument and adds the forward slash delimiter.
@@ -270,25 +271,25 @@ class Log
 	
     public function debug($logMessage, $flags=FILE_APPEND)
     {
-        if(ANET_LOG_DEBUG >= ANET_LOG_LEVEL){
+        if(ANET_LOG_DEBUG >= $this->logLevel){
             $this->log(ANET_LOG_DEBUG_PREFIX, $logMessage,$flags);
         }
     }
 	
     public function info($logMessage, $flags=FILE_APPEND){
-        if(ANET_LOG_INFO >= ANET_LOG_LEVEL) {
+        if(ANET_LOG_INFO >= $this->logLevel) {
             $this->log(ANET_LOG_INFO_PREFIX, $logMessage,$flags);
         }
     }
 	
 	public function warn($logMessage, $flags=FILE_APPEND){
-        if(ANET_LOG_WARN >= ANET_LOG_LEVEL) {
+        if(ANET_LOG_WARN >= $this->logLevel) {
             $this->log(ANET_LOG_WARN_PREFIX, $logMessage,$flags);
         }
     }
 	
     public function error($logMessage, $flags=FILE_APPEND){
-        if(ANET_LOG_ERROR >= ANET_LOG_LEVEL) {
+        if(ANET_LOG_ERROR >= $this->logLevel) {
             $this->log(ANET_LOG_ERROR_PREFIX, $logMessage,$flags);
         }
     }
@@ -308,27 +309,42 @@ class Log
 	
 	public function debugFormat($format, $args=array(),  $flags=FILE_APPEND)
     {
-        if(ANET_LOG_DEBUG >= ANET_LOG_LEVEL){
+        if(ANET_LOG_DEBUG >= $this->logLevel){
             $this->logFormat(ANET_LOG_DEBUG_PREFIX, $format, $args , $flags);
         }
     }
 	
 	public function infoFormat($format, $args=array(),  $flags=FILE_APPEND){
-        if(ANET_LOG_INFO >= ANET_LOG_LEVEL) {
+        if(ANET_LOG_INFO >= $this->logLevel) {
             $this->logFormat(ANET_LOG_INFO_PREFIX, $format, $args , $flags);
         }
     }
 	
 	public function warnFormat($format, $args=array(),  $flags=FILE_APPEND){
-        if(ANET_LOG_WARN >= ANET_LOG_LEVEL) {
+        if(ANET_LOG_WARN >= $this->logLevel) {
             $this->logFormat(ANET_LOG_WARN_PREFIX, $format, $args , $flags);
         }
     }
 	
     public function errorFormat($format, $args=array(),  $flags=FILE_APPEND){
-        if(ANET_LOG_ERROR >= ANET_LOG_LEVEL) {
+        if(ANET_LOG_ERROR >= $this->logLevel) {
 			$this->logFormat(ANET_LOG_ERROR_PREFIX, $format, $args , $flags);
         }
+    }
+
+    /**
+     * @param string $logLevel
+       possible values = ANET_LOG_DEBUG, ANET_LOG_INFO, ANET_LOG_WARN, ANET_LOG_ERROR
+     */
+    public function setLogLevel($logLevel){
+        $this->logLevel = $logLevel;
+    }
+
+    /**
+     * @return string
+     */
+    public function getLogLevel(){
+        return $this->logLevel;
     }
 
     /**

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -32,7 +32,7 @@
         
         <!-- Enter your test account credentials to run tests against sandbox. -->
         <const name="AUTHORIZENET_API_LOGIN_ID" value="5KP3u95bQpv" />
-        <const name="AUTHORIZENET_TRANSACTION_KEY" value="4Ktq966gC55GAX7S" />
+        <const name="AUTHORIZENET_TRANSACTION_KEY" value="346HZ32z3fP4hTG2" />
         <const name="AUTHORIZENET_MD5_SETTING" value="" />
         
         <!-- Enter your live account credentials to run tests against production gateway. -->

--- a/tests/AuthorizeNetCIM_Test.php
+++ b/tests/AuthorizeNetCIM_Test.php
@@ -448,7 +448,7 @@ class AuthorizeNetCIM_Test extends PHPUnit_Framework_TestCase
   {
     // A valid response should be received when a merchant has zero customer profiles...
     // Hence, first testing using specific credentials for a merchant which has zero customer profiles...  
-    $request = new AuthorizeNetCIM('5KP3u95bQpv','4Ktq966gC55GAX7S');
+    $request = new AuthorizeNetCIM('5KP3u95bQpv','346HZ32z3fP4hTG2');
     $response = $request->getCustomerProfileIds();
 
 	  


### PR DESCRIPTION
- Logging -setLogLevel
- Dependency - symfony/yaml 3.1 added
                     - goetas/xsd2php added to allow master update script to work
- Updated  default credentials - phpunit.xml.dist and  tests/AuthorizeNetCIM_Test.php
- Unit test fixes - custom_fields(userField in the xsd) is no longer present at the end of transact response. `transHashSha2` was recently added as the last element in transact response. The index for each response field from 0 - 54 is fixed as seen in AuthorizeNet_AIM Guide  and after that, custom fields earlier used to be present at the end of the transaction response. 
