### PR TITLE
Expose logger through api operation base

### DIFF
--- a/lib/net/authorize/api/controller/base/ApiOperationBase.php
+++ b/lib/net/authorize/api/controller/base/ApiOperationBase.php
@@ -38,7 +38,12 @@ abstract class ApiOperationBase implements IApiOperation
      * @var \net\authorize\util\HttpClient;
      */
     public $httpClient = null;
-    private $logger = null;
+
+    /**
+     * @var \net\authorize\util\Log
+     */
+    private $logger;
+
     /**
      * Constructor.
      *
@@ -130,6 +135,14 @@ abstract class ApiOperationBase implements IApiOperation
         $this->logger->info("Response De-Serialization End");
 
         $this->afterExecute();
+    }
+
+    /**
+     * @return \net\authorize\util\Log
+     */
+    public function getLogger()
+    {
+        return $this->logger;
     }
 
     private function validate()

--- a/lib/net/authorize/util/Log.php
+++ b/lib/net/authorize/util/Log.php
@@ -3,22 +3,6 @@ namespace net\authorize\util;
 
 use net\authorize\util\ANetSensitiveFields;
 
-define ("ANET_LOG_FILES_APPEND",true);
-
-define("ANET_LOG_DEBUG_PREFIX","DEBUG");
-define("ANET_LOG_INFO_PREFIX","INFO");
-define("ANET_LOG_WARN_PREFIX","WARN");
-define("ANET_LOG_ERROR_PREFIX","ERROR");
-
-//log levels
-define('ANET_LOG_DEBUG',1);
-define("ANET_LOG_INFO",2);
-define("ANET_LOG_WARN",3);
-define("ANET_LOG_ERROR",4);
-
-//set level
-define("ANET_LOG_LEVEL",ANET_LOG_DEBUG);
-
 /**
  * A class to implement logging.
  *
@@ -28,9 +12,29 @@ define("ANET_LOG_LEVEL",ANET_LOG_DEBUG);
 
 class Log
 {
-    private $sensitiveXmlTags = NULL;
+    const ANET_LOG_FILES_APPEND = true;
+
+    const ANET_LOG_DEBUG_PREFIX = "DEBUG";
+
+    const ANET_LOG_INFO_PREFIX  = "INFO";
+
+    const ANET_LOG_WARN_PREFIX  = "WARN";
+
+    const ANET_LOG_ERROR_PREFIX = "ERROR";
+
+    const ANET_LOG_DEBUG        = 1;
+
+    const ANET_LOG_INFO         = 2;
+
+    const ANET_LOG_WARN         = 3;
+
+    const ANET_LOG_ERROR        = 4;
+
+    private $sensitiveXmlTags = null;
+
     private $logFile = '';
-    private $logLevel = ANET_LOG_LEVEL;
+
+    private $logLevel = self::ANET_LOG_DEBUG;
 	
 	/**
 	* Takes a regex pattern (string) as argument and adds the forward slash delimiter.
@@ -271,26 +275,26 @@ class Log
 	
     public function debug($logMessage, $flags=FILE_APPEND)
     {
-        if(ANET_LOG_DEBUG >= $this->logLevel){
-            $this->log(ANET_LOG_DEBUG_PREFIX, $logMessage,$flags);
+        if(self::ANET_LOG_DEBUG >= $this->logLevel){
+            $this->log(self::ANET_LOG_DEBUG_PREFIX, $logMessage,$flags);
         }
     }
 	
     public function info($logMessage, $flags=FILE_APPEND){
-        if(ANET_LOG_INFO >= $this->logLevel) {
-            $this->log(ANET_LOG_INFO_PREFIX, $logMessage,$flags);
+        if(self::ANET_LOG_INFO >= $this->logLevel) {
+            $this->log(self::ANET_LOG_INFO_PREFIX, $logMessage,$flags);
         }
     }
 	
 	public function warn($logMessage, $flags=FILE_APPEND){
-        if(ANET_LOG_WARN >= $this->logLevel) {
-            $this->log(ANET_LOG_WARN_PREFIX, $logMessage,$flags);
+        if(self::ANET_LOG_WARN >= $this->logLevel) {
+            $this->log(self::ANET_LOG_WARN_PREFIX, $logMessage,$flags);
         }
     }
 	
     public function error($logMessage, $flags=FILE_APPEND){
-        if(ANET_LOG_ERROR >= $this->logLevel) {
-            $this->log(ANET_LOG_ERROR_PREFIX, $logMessage,$flags);
+        if(self::ANET_LOG_ERROR >= $this->logLevel) {
+            $this->log(self::ANET_LOG_ERROR_PREFIX, $logMessage,$flags);
         }
     }
 	
@@ -309,26 +313,26 @@ class Log
 	
 	public function debugFormat($format, $args=array(),  $flags=FILE_APPEND)
     {
-        if(ANET_LOG_DEBUG >= $this->logLevel){
-            $this->logFormat(ANET_LOG_DEBUG_PREFIX, $format, $args , $flags);
+        if(self::ANET_LOG_DEBUG >= $this->logLevel){
+            $this->logFormat( self::ANET_LOG_DEBUG_PREFIX, $format, $args , $flags);
         }
     }
 	
 	public function infoFormat($format, $args=array(),  $flags=FILE_APPEND){
-        if(ANET_LOG_INFO >= $this->logLevel) {
-            $this->logFormat(ANET_LOG_INFO_PREFIX, $format, $args , $flags);
+        if(self::ANET_LOG_INFO >= $this->logLevel) {
+            $this->logFormat( self::ANET_LOG_INFO_PREFIX, $format, $args , $flags);
         }
     }
 	
 	public function warnFormat($format, $args=array(),  $flags=FILE_APPEND){
-        if(ANET_LOG_WARN >= $this->logLevel) {
-            $this->logFormat(ANET_LOG_WARN_PREFIX, $format, $args , $flags);
+        if(self::ANET_LOG_WARN >= $this->logLevel) {
+            $this->logFormat(self::ANET_LOG_WARN_PREFIX, $format, $args , $flags);
         }
     }
 	
     public function errorFormat($format, $args=array(),  $flags=FILE_APPEND){
-        if(ANET_LOG_ERROR >= $this->logLevel) {
-			$this->logFormat(ANET_LOG_ERROR_PREFIX, $format, $args , $flags);
+        if(self::ANET_LOG_ERROR >= $this->logLevel) {
+			$this->logFormat(self::ANET_LOG_ERROR_PREFIX, $format, $args , $flags);
         }
     }
 

--- a/tests/Controller_Test.php
+++ b/tests/Controller_Test.php
@@ -180,4 +180,25 @@ class Controller_Test extends PHPUnit_Framework_TestCase
             $this->assertEquals("Successful.", $response->getText());
         }
     }
+
+    public function testGetLogger()
+    {
+        $name           = ( defined( 'AUTHORIZENET_API_LOGIN_ID' ) && '' != AUTHORIZENET_API_LOGIN_ID ) ? AUTHORIZENET_API_LOGIN_ID : getenv( "api_login_id" );
+        $transactionKey = ( defined( 'AUTHORIZENET_TRANSACTION_KEY' ) && '' != AUTHORIZENET_TRANSACTION_KEY ) ? AUTHORIZENET_TRANSACTION_KEY : getenv( "transaction_key" );
+
+        $merchantAuthentication = new net\authorize\api\contract\v1\MerchantAuthenticationType();
+        $merchantAuthentication->setName( $name );
+        $merchantAuthentication->setTransactionKey( $transactionKey );
+
+        $refId  = 'ref' . time();
+
+        $request = new \net\authorize\api\contract\v1\ANetApiRequestType();
+        $request->setRefId( $refId );
+        $request->setMerchantAuthentication( $merchantAuthentication );
+
+        $controller = new net\authorize\api\controller\IsAliveController( $request );
+        $logger = $controller->getLogger();
+
+        $this->assertInstanceOf(\net\authorize\util\Log::class, $logger);
+    }
 }


### PR DESCRIPTION
Problem:
There is currently no way to set the log level of the logger class

Solution:
Expose the logger via a getter on the API Operation Base class. Any class extending this (Controllers) will now have access to the logger and be able to invoke `$controller->getLogger()->setLogLevel(Log::ANET_LOG_WARN);`

Notable changes:
 - All globally defined variables have been moved into the class scope as public constants. This will prevent implementers of this library from defining the global variables and raising PHP notices. This also allows for any IDE to pick up on the public visibility and give the constants as recommended selections.
 - `$logger` should never be null

Fixes #186 