### PR TITLE
Log level

### DIFF
--- a/lib/net/authorize/api/controller/ARBCancelSubscriptionController.php
+++ b/lib/net/authorize/api/controller/ARBCancelSubscriptionController.php
@@ -3,13 +3,14 @@ namespace net\authorize\api\controller;
 
 use net\authorize\api\contract\v1\AnetApiRequestType;
 use net\authorize\api\controller\base\ApiOperationBase;
+use net\authorize\util\Log;
 
 class ARBCancelSubscriptionController extends ApiOperationBase
 {
-    public function __construct(AnetApiRequestType $request)
+    public function __construct(AnetApiRequestType $request, Log $logger = null)
     {
         $responseType = 'net\authorize\api\contract\v1\ARBCancelSubscriptionResponse';
-        parent::__construct($request, $responseType);
+        parent::__construct($request, $responseType, $logger);
     }
 
     protected function validateRequest()

--- a/lib/net/authorize/api/controller/ARBCreateSubscriptionController.php
+++ b/lib/net/authorize/api/controller/ARBCreateSubscriptionController.php
@@ -6,10 +6,10 @@ use net\authorize\api\controller\base\ApiOperationBase;
 
 class ARBCreateSubscriptionController extends ApiOperationBase
 {
-    public function __construct(AnetApiRequestType $request)
+    public function __construct(AnetApiRequestType $request, \net\authorize\util\Log $logger = null)
     {
         $responseType = 'net\authorize\api\contract\v1\ARBCreateSubscriptionResponse';
-        parent::__construct($request, $responseType);
+        parent::__construct($request, $responseType, $logger);
     }
 
     protected function validateRequest()

--- a/lib/net/authorize/api/controller/ARBGetSubscriptionController.php
+++ b/lib/net/authorize/api/controller/ARBGetSubscriptionController.php
@@ -3,13 +3,14 @@ namespace net\authorize\api\controller;
 
 use net\authorize\api\contract\v1\AnetApiRequestType;
 use net\authorize\api\controller\base\ApiOperationBase;
+use net\authorize\util\Log;
 
 class ARBGetSubscriptionController extends ApiOperationBase
 {
-    public function __construct(AnetApiRequestType $request)
+    public function __construct(AnetApiRequestType $request, Log $logger = null)
     {
         $responseType = 'net\authorize\api\contract\v1\ARBGetSubscriptionResponse';
-        parent::__construct($request, $responseType);
+        parent::__construct($request, $responseType, $logger);
     }
 
     protected function validateRequest()

--- a/lib/net/authorize/api/controller/ARBGetSubscriptionListController.php
+++ b/lib/net/authorize/api/controller/ARBGetSubscriptionListController.php
@@ -3,13 +3,14 @@ namespace net\authorize\api\controller;
 
 use net\authorize\api\contract\v1\AnetApiRequestType;
 use net\authorize\api\controller\base\ApiOperationBase;
+use net\authorize\util\Log;
 
 class ARBGetSubscriptionListController extends ApiOperationBase
 {
-    public function __construct(AnetApiRequestType $request)
+    public function __construct(AnetApiRequestType $request, Log $logger = null)
     {
         $responseType = 'net\authorize\api\contract\v1\ARBGetSubscriptionListResponse';
-        parent::__construct($request, $responseType);
+        parent::__construct($request, $responseType, $logger);
     }
 
     protected function validateRequest()

--- a/lib/net/authorize/api/controller/ARBGetSubscriptionStatusController.php
+++ b/lib/net/authorize/api/controller/ARBGetSubscriptionStatusController.php
@@ -3,13 +3,14 @@ namespace net\authorize\api\controller;
 
 use net\authorize\api\contract\v1\AnetApiRequestType;
 use net\authorize\api\controller\base\ApiOperationBase;
+use net\authorize\util\Log;
 
 class ARBGetSubscriptionStatusController extends ApiOperationBase
 {
-    public function __construct(AnetApiRequestType $request)
+    public function __construct(AnetApiRequestType $request, Log $logger = null)
     {
         $responseType = 'net\authorize\api\contract\v1\ARBGetSubscriptionStatusResponse';
-        parent::__construct($request, $responseType);
+        parent::__construct($request, $responseType, $logger);
     }
 
     protected function validateRequest()

--- a/lib/net/authorize/api/controller/ARBUpdateSubscriptionController.php
+++ b/lib/net/authorize/api/controller/ARBUpdateSubscriptionController.php
@@ -3,13 +3,14 @@ namespace net\authorize\api\controller;
 
 use net\authorize\api\contract\v1\AnetApiRequestType;
 use net\authorize\api\controller\base\ApiOperationBase;
+use net\authorize\util\Log;
 
 class ARBUpdateSubscriptionController extends ApiOperationBase
 {
-    public function __construct(AnetApiRequestType $request)
+    public function __construct(AnetApiRequestType $request, Log $logger = null)
     {
         $responseType = 'net\authorize\api\contract\v1\ARBUpdateSubscriptionResponse';
-        parent::__construct($request, $responseType);
+        parent::__construct($request, $responseType, $logger);
     }
 
     protected function validateRequest()

--- a/lib/net/authorize/api/controller/AuthenticateTestController.php
+++ b/lib/net/authorize/api/controller/AuthenticateTestController.php
@@ -3,13 +3,14 @@ namespace net\authorize\api\controller;
 
 use net\authorize\api\contract\v1\AnetApiRequestType;
 use net\authorize\api\controller\base\ApiOperationBase;
+use net\authorize\util\Log;
 
 class AuthenticateTestController extends ApiOperationBase
 {
-    public function __construct(AnetApiRequestType $request)
+    public function __construct(AnetApiRequestType $request, Log $logger = null)
     {
         $responseType = 'net\authorize\api\contract\v1\AuthenticateTestResponse';
-        parent::__construct($request, $responseType);
+        parent::__construct($request, $responseType, $logger);
     }
 
     protected function validateRequest()

--- a/lib/net/authorize/api/controller/CreateCustomerPaymentProfileController.php
+++ b/lib/net/authorize/api/controller/CreateCustomerPaymentProfileController.php
@@ -3,13 +3,14 @@ namespace net\authorize\api\controller;
 
 use net\authorize\api\contract\v1\AnetApiRequestType;
 use net\authorize\api\controller\base\ApiOperationBase;
+use net\authorize\util\Log;
 
 class CreateCustomerPaymentProfileController extends ApiOperationBase
 {
-    public function __construct(AnetApiRequestType $request)
+    public function __construct(AnetApiRequestType $request, Log $logger = null)
     {
         $responseType = 'net\authorize\api\contract\v1\CreateCustomerPaymentProfileResponse';
-        parent::__construct($request, $responseType);
+        parent::__construct($request, $responseType, $logger);
     }
 
     protected function validateRequest()

--- a/lib/net/authorize/api/controller/CreateCustomerProfileController.php
+++ b/lib/net/authorize/api/controller/CreateCustomerProfileController.php
@@ -3,13 +3,14 @@ namespace net\authorize\api\controller;
 
 use net\authorize\api\contract\v1\AnetApiRequestType;
 use net\authorize\api\controller\base\ApiOperationBase;
+use net\authorize\util\Log;
 
 class CreateCustomerProfileController extends ApiOperationBase
 {
-    public function __construct(AnetApiRequestType $request)
+    public function __construct(AnetApiRequestType $request, Log $logger = null)
     {
         $responseType = 'net\authorize\api\contract\v1\CreateCustomerProfileResponse';
-        parent::__construct($request, $responseType);
+        parent::__construct($request, $responseType, $logger);
     }
 
     protected function validateRequest()

--- a/lib/net/authorize/api/controller/CreateCustomerProfileFromTransactionController.php
+++ b/lib/net/authorize/api/controller/CreateCustomerProfileFromTransactionController.php
@@ -3,13 +3,14 @@ namespace net\authorize\api\controller;
 
 use net\authorize\api\contract\v1\AnetApiRequestType;
 use net\authorize\api\controller\base\ApiOperationBase;
+use net\authorize\util\Log;
 
 class CreateCustomerProfileFromTransactionController extends ApiOperationBase
 {
-    public function __construct(AnetApiRequestType $request)
+    public function __construct(AnetApiRequestType $request, Log $logger = null)
     {
         $responseType = 'net\authorize\api\contract\v1\CreateCustomerProfileResponse';
-        parent::__construct($request, $responseType);
+        parent::__construct($request, $responseType, $logger);
     }
 
     protected function validateRequest()

--- a/lib/net/authorize/api/controller/CreateCustomerProfileTransactionController.php
+++ b/lib/net/authorize/api/controller/CreateCustomerProfileTransactionController.php
@@ -3,13 +3,14 @@ namespace net\authorize\api\controller;
 
 use net\authorize\api\contract\v1\AnetApiRequestType;
 use net\authorize\api\controller\base\ApiOperationBase;
+use net\authorize\util\Log;
 
 class CreateCustomerProfileTransactionController extends ApiOperationBase
 {
-    public function __construct(AnetApiRequestType $request)
+    public function __construct(AnetApiRequestType $request, Log $logger = null)
     {
         $responseType = 'net\authorize\api\contract\v1\CreateCustomerProfileTransactionResponse';
-        parent::__construct($request, $responseType);
+        parent::__construct($request, $responseType, $logger);
     }
 
     protected function validateRequest()

--- a/lib/net/authorize/api/controller/CreateCustomerShippingAddressController.php
+++ b/lib/net/authorize/api/controller/CreateCustomerShippingAddressController.php
@@ -6,10 +6,10 @@ use net\authorize\api\controller\base\ApiOperationBase;
 
 class CreateCustomerShippingAddressController extends ApiOperationBase
 {
-    public function __construct(AnetApiRequestType $request)
+    public function __construct(AnetApiRequestType $request, Log $logger = null)
     {
         $responseType = 'net\authorize\api\contract\v1\CreateCustomerShippingAddressResponse';
-        parent::__construct($request, $responseType);
+        parent::__construct($request, $responseType, $logger);
     }
 
     protected function validateRequest()

--- a/lib/net/authorize/api/controller/CreateTransactionController.php
+++ b/lib/net/authorize/api/controller/CreateTransactionController.php
@@ -6,10 +6,10 @@ use net\authorize\api\controller\base\ApiOperationBase;
 
 class CreateTransactionController extends ApiOperationBase
 {
-    public function __construct(AnetApiRequestType $request)
+    public function __construct(AnetApiRequestType $request, \net\authorize\util\Log $logger = null)
     {
         $responseType = 'net\authorize\api\contract\v1\CreateTransactionResponse';
-        parent::__construct($request, $responseType);
+        parent::__construct($request, $responseType, $logger);
     }
 
     protected function validateRequest()

--- a/lib/net/authorize/api/controller/DecryptPaymentDataController.php
+++ b/lib/net/authorize/api/controller/DecryptPaymentDataController.php
@@ -6,10 +6,10 @@ use net\authorize\api\controller\base\ApiOperationBase;
 
 class DecryptPaymentDataController extends ApiOperationBase
 {
-    public function __construct(AnetApiRequestType $request)
+    public function __construct(AnetApiRequestType $request, \net\authorize\util\Log $logger = null)
     {
         $responseType = 'net\authorize\api\contract\v1\DecryptPaymentDataResponse';
-        parent::__construct($request, $responseType);
+        parent::__construct($request, $responseType, $logger);
     }
 
     protected function validateRequest()

--- a/lib/net/authorize/api/controller/DeleteCustomerPaymentProfileController.php
+++ b/lib/net/authorize/api/controller/DeleteCustomerPaymentProfileController.php
@@ -6,10 +6,10 @@ use net\authorize\api\controller\base\ApiOperationBase;
 
 class DeleteCustomerPaymentProfileController extends ApiOperationBase
 {
-    public function __construct(AnetApiRequestType $request)
+    public function __construct(AnetApiRequestType $request, \net\authorize\util\Log $logger = null)
     {
         $responseType = 'net\authorize\api\contract\v1\DeleteCustomerPaymentProfileResponse';
-        parent::__construct($request, $responseType);
+        parent::__construct($request, $responseType, $logger);
     }
 
     protected function validateRequest()

--- a/lib/net/authorize/api/controller/DeleteCustomerProfileController.php
+++ b/lib/net/authorize/api/controller/DeleteCustomerProfileController.php
@@ -6,10 +6,10 @@ use net\authorize\api\controller\base\ApiOperationBase;
 
 class DeleteCustomerProfileController extends ApiOperationBase
 {
-    public function __construct(AnetApiRequestType $request)
+    public function __construct(AnetApiRequestType $request, \net\authorize\util\Log $logger = null)
     {
         $responseType = 'net\authorize\api\contract\v1\DeleteCustomerProfileResponse';
-        parent::__construct($request, $responseType);
+        parent::__construct($request, $responseType, $logger);
     }
 
     protected function validateRequest()

--- a/lib/net/authorize/api/controller/DeleteCustomerShippingAddressController.php
+++ b/lib/net/authorize/api/controller/DeleteCustomerShippingAddressController.php
@@ -6,10 +6,10 @@ use net\authorize\api\controller\base\ApiOperationBase;
 
 class DeleteCustomerShippingAddressController extends ApiOperationBase
 {
-    public function __construct(AnetApiRequestType $request)
+    public function __construct(AnetApiRequestType $request, \net\authorize\util\Log $logger = null)
     {
         $responseType = 'net\authorize\api\contract\v1\DeleteCustomerShippingAddressResponse';
-        parent::__construct($request, $responseType);
+        parent::__construct($request, $responseType, $logger);
     }
 
     protected function validateRequest()

--- a/lib/net/authorize/api/controller/GetAUJobDetailsController.php
+++ b/lib/net/authorize/api/controller/GetAUJobDetailsController.php
@@ -6,10 +6,10 @@ use net\authorize\api\controller\base\ApiOperationBase;
 
 class GetAUJobDetailsController extends ApiOperationBase
 {
-    public function __construct(AnetApiRequestType $request)
+    public function __construct(AnetApiRequestType $request, \net\authorize\util\Log $logger = null)
     {
         $responseType = 'net\authorize\api\contract\v1\GetAUJobDetailsResponse';
-        parent::__construct($request, $responseType);
+        parent::__construct($request, $responseType, $logger);
     }
 
     protected function validateRequest()

--- a/lib/net/authorize/api/controller/GetAUJobSummaryController.php
+++ b/lib/net/authorize/api/controller/GetAUJobSummaryController.php
@@ -6,10 +6,10 @@ use net\authorize\api\controller\base\ApiOperationBase;
 
 class GetAUJobSummaryController extends ApiOperationBase
 {
-    public function __construct(AnetApiRequestType $request)
+    public function __construct(AnetApiRequestType $request, \net\authorize\util\Log $logger = null)
     {
         $responseType = 'net\authorize\api\contract\v1\GetAUJobSummaryResponse';
-        parent::__construct($request, $responseType);
+        parent::__construct($request, $responseType, $logger);
     }
 
     protected function validateRequest()

--- a/lib/net/authorize/api/controller/GetBatchStatisticsController.php
+++ b/lib/net/authorize/api/controller/GetBatchStatisticsController.php
@@ -6,10 +6,10 @@ use net\authorize\api\controller\base\ApiOperationBase;
 
 class GetBatchStatisticsController extends ApiOperationBase
 {
-    public function __construct(AnetApiRequestType $request)
+    public function __construct(AnetApiRequestType $request, \net\authorize\util\Log $logger = null)
     {
         $responseType = 'net\authorize\api\contract\v1\GetBatchStatisticsResponse';
-        parent::__construct($request, $responseType);
+        parent::__construct($request, $responseType, $logger);
     }
 
     protected function validateRequest()

--- a/lib/net/authorize/api/controller/GetCustomerPaymentProfileController.php
+++ b/lib/net/authorize/api/controller/GetCustomerPaymentProfileController.php
@@ -6,10 +6,10 @@ use net\authorize\api\controller\base\ApiOperationBase;
 
 class GetCustomerPaymentProfileController extends ApiOperationBase
 {
-    public function __construct(AnetApiRequestType $request)
+    public function __construct(AnetApiRequestType $request, \net\authorize\util\Log $logger = null)
     {
         $responseType = 'net\authorize\api\contract\v1\GetCustomerPaymentProfileResponse';
-        parent::__construct($request, $responseType);
+        parent::__construct($request, $responseType, $logger);
     }
 
     protected function validateRequest()

--- a/lib/net/authorize/api/controller/GetCustomerPaymentProfileListController.php
+++ b/lib/net/authorize/api/controller/GetCustomerPaymentProfileListController.php
@@ -6,10 +6,10 @@ use net\authorize\api\controller\base\ApiOperationBase;
 
 class GetCustomerPaymentProfileListController extends ApiOperationBase
 {
-    public function __construct(AnetApiRequestType $request)
+    public function __construct(AnetApiRequestType $request, \net\authorize\util\Log $logger = null)
     {
         $responseType = 'net\authorize\api\contract\v1\GetCustomerPaymentProfileListResponse';
-        parent::__construct($request, $responseType);
+        parent::__construct($request, $responseType, $logger);
     }
 
     protected function validateRequest()

--- a/lib/net/authorize/api/controller/GetCustomerProfileController.php
+++ b/lib/net/authorize/api/controller/GetCustomerProfileController.php
@@ -6,10 +6,10 @@ use net\authorize\api\controller\base\ApiOperationBase;
 
 class GetCustomerProfileController extends ApiOperationBase
 {
-    public function __construct(AnetApiRequestType $request)
+    public function __construct(AnetApiRequestType $request, \net\authorize\util\Log $logger = null)
     {
         $responseType = 'net\authorize\api\contract\v1\GetCustomerProfileResponse';
-        parent::__construct($request, $responseType);
+        parent::__construct($request, $responseType, $logger);
     }
 
     protected function validateRequest()

--- a/lib/net/authorize/api/controller/GetCustomerProfileIdsController.php
+++ b/lib/net/authorize/api/controller/GetCustomerProfileIdsController.php
@@ -6,10 +6,10 @@ use net\authorize\api\controller\base\ApiOperationBase;
 
 class GetCustomerProfileIdsController extends ApiOperationBase
 {
-    public function __construct(AnetApiRequestType $request)
+    public function __construct(AnetApiRequestType $request, \net\authorize\util\Log $logger = null)
     {
         $responseType = 'net\authorize\api\contract\v1\GetCustomerProfileIdsResponse';
-        parent::__construct($request, $responseType);
+        parent::__construct($request, $responseType, $logger);
     }
 
     protected function validateRequest()

--- a/lib/net/authorize/api/controller/GetCustomerShippingAddressController.php
+++ b/lib/net/authorize/api/controller/GetCustomerShippingAddressController.php
@@ -6,10 +6,10 @@ use net\authorize\api\controller\base\ApiOperationBase;
 
 class GetCustomerShippingAddressController extends ApiOperationBase
 {
-    public function __construct(AnetApiRequestType $request)
+    public function __construct(AnetApiRequestType $request, \net\authorize\util\Log $logger = null)
     {
         $responseType = 'net\authorize\api\contract\v1\GetCustomerShippingAddressResponse';
-        parent::__construct($request, $responseType);
+        parent::__construct($request, $responseType, $logger);
     }
 
     protected function validateRequest()

--- a/lib/net/authorize/api/controller/GetHostedProfilePageController.php
+++ b/lib/net/authorize/api/controller/GetHostedProfilePageController.php
@@ -6,10 +6,10 @@ use net\authorize\api\controller\base\ApiOperationBase;
 
 class GetHostedProfilePageController extends ApiOperationBase
 {
-    public function __construct(AnetApiRequestType $request)
+    public function __construct(AnetApiRequestType $request, \net\authorize\util\Log $logger = null)
     {
         $responseType = 'net\authorize\api\contract\v1\GetHostedProfilePageResponse';
-        parent::__construct($request, $responseType);
+        parent::__construct($request, $responseType, $logger);
     }
 
     protected function validateRequest()

--- a/lib/net/authorize/api/controller/GetSettledBatchListController.php
+++ b/lib/net/authorize/api/controller/GetSettledBatchListController.php
@@ -6,10 +6,10 @@ use net\authorize\api\controller\base\ApiOperationBase;
 
 class GetSettledBatchListController extends ApiOperationBase
 {
-    public function __construct(AnetApiRequestType $request)
+    public function __construct(AnetApiRequestType $request, \net\authorize\util\Log $logger = null)
     {
         $responseType = 'net\authorize\api\contract\v1\GetSettledBatchListResponse';
-        parent::__construct($request, $responseType);
+        parent::__construct($request, $responseType, $logger);
     }
 
     protected function validateRequest()

--- a/lib/net/authorize/api/controller/GetTransactionDetailsController.php
+++ b/lib/net/authorize/api/controller/GetTransactionDetailsController.php
@@ -3,13 +3,14 @@ namespace net\authorize\api\controller;
 
 use net\authorize\api\contract\v1\AnetApiRequestType;
 use net\authorize\api\controller\base\ApiOperationBase;
+use net\authorize\util\Log;
 
 class GetTransactionDetailsController extends ApiOperationBase
 {
-    public function __construct(AnetApiRequestType $request)
+    public function __construct(AnetApiRequestType $request, Log $logger = null)
     {
         $responseType = 'net\authorize\api\contract\v1\GetTransactionDetailsResponse';
-        parent::__construct($request, $responseType);
+        parent::__construct($request, $responseType, $logger);
     }
 
     protected function validateRequest()

--- a/lib/net/authorize/api/controller/GetTransactionListController.php
+++ b/lib/net/authorize/api/controller/GetTransactionListController.php
@@ -6,10 +6,10 @@ use net\authorize\api\controller\base\ApiOperationBase;
 
 class GetTransactionListController extends ApiOperationBase
 {
-    public function __construct(AnetApiRequestType $request)
+    public function __construct(AnetApiRequestType $request, \net\authorize\util\Log $logger = null)
     {
         $responseType = 'net\authorize\api\contract\v1\GetTransactionListResponse';
-        parent::__construct($request, $responseType);
+        parent::__construct($request, $responseType, $logger);
     }
 
     protected function validateRequest()

--- a/lib/net/authorize/api/controller/GetUnsettledTransactionListController.php
+++ b/lib/net/authorize/api/controller/GetUnsettledTransactionListController.php
@@ -6,10 +6,10 @@ use net\authorize\api\controller\base\ApiOperationBase;
 
 class GetUnsettledTransactionListController extends ApiOperationBase
 {
-    public function __construct(AnetApiRequestType $request)
+    public function __construct(AnetApiRequestType $request, \net\authorize\util\Log $logger = null)
     {
         $responseType = 'net\authorize\api\contract\v1\GetUnsettledTransactionListResponse';
-        parent::__construct($request, $responseType);
+        parent::__construct($request, $responseType, $logger);
     }
 
     protected function validateRequest()

--- a/lib/net/authorize/api/controller/IsAliveController.php
+++ b/lib/net/authorize/api/controller/IsAliveController.php
@@ -6,10 +6,10 @@ use net\authorize\api\controller\base\ApiOperationBase;
 
 class IsAliveController extends ApiOperationBase
 {
-    public function __construct(AnetApiRequestType $request)
+    public function __construct(AnetApiRequestType $request, \net\authorize\util\Log $logger = null)
     {
         $responseType = 'net\authorize\api\contract\v1\IsAliveResponse';
-        parent::__construct($request, $responseType);
+        parent::__construct($request, $responseType, $logger);
     }
 
     protected function validateRequest()

--- a/lib/net/authorize/api/controller/LogoutController.php
+++ b/lib/net/authorize/api/controller/LogoutController.php
@@ -6,10 +6,10 @@ use net\authorize\api\controller\base\ApiOperationBase;
 
 class LogoutController extends ApiOperationBase
 {
-    public function __construct(AnetApiRequestType $request)
+    public function __construct(AnetApiRequestType $request, \net\authorize\util\Log $logger = null)
     {
         $responseType = 'net\authorize\api\contract\v1\LogoutResponse';
-        parent::__construct($request, $responseType);
+        parent::__construct($request, $responseType, $logger);
     }
 
     protected function validateRequest()

--- a/lib/net/authorize/api/controller/MobileDeviceLoginController.php
+++ b/lib/net/authorize/api/controller/MobileDeviceLoginController.php
@@ -6,10 +6,10 @@ use net\authorize\api\controller\base\ApiOperationBase;
 
 class MobileDeviceLoginController extends ApiOperationBase
 {
-    public function __construct(AnetApiRequestType $request)
+    public function __construct(AnetApiRequestType $request, \net\authorize\util\Log $logger = null)
     {
         $responseType = 'net\authorize\api\contract\v1\MobileDeviceLoginResponse';
-        parent::__construct($request, $responseType);
+        parent::__construct($request, $responseType, $logger);
     }
 
     protected function validateRequest()

--- a/lib/net/authorize/api/controller/MobileDeviceRegistrationController.php
+++ b/lib/net/authorize/api/controller/MobileDeviceRegistrationController.php
@@ -6,10 +6,10 @@ use net\authorize\api\controller\base\ApiOperationBase;
 
 class MobileDeviceRegistrationController extends ApiOperationBase
 {
-    public function __construct(AnetApiRequestType $request)
+    public function __construct(AnetApiRequestType $request, \net\authorize\util\Log $logger = null)
     {
         $responseType = 'net\authorize\api\contract\v1\MobileDeviceRegistrationResponse';
-        parent::__construct($request, $responseType);
+        parent::__construct($request, $responseType, $logger);
     }
 
     protected function validateRequest()

--- a/lib/net/authorize/api/controller/SendCustomerTransactionReceiptController.php
+++ b/lib/net/authorize/api/controller/SendCustomerTransactionReceiptController.php
@@ -6,10 +6,10 @@ use net\authorize\api\controller\base\ApiOperationBase;
 
 class SendCustomerTransactionReceiptController extends ApiOperationBase
 {
-    public function __construct(AnetApiRequestType $request)
+    public function __construct(AnetApiRequestType $request, \net\authorize\util\Log $logger = null)
     {
         $responseType = 'net\authorize\api\contract\v1\SendCustomerTransactionReceiptResponse';
-        parent::__construct($request, $responseType);
+        parent::__construct($request, $responseType, $logger);
     }
 
     protected function validateRequest()

--- a/lib/net/authorize/api/controller/UpdateCustomerPaymentProfileController.php
+++ b/lib/net/authorize/api/controller/UpdateCustomerPaymentProfileController.php
@@ -6,10 +6,10 @@ use net\authorize\api\controller\base\ApiOperationBase;
 
 class UpdateCustomerPaymentProfileController extends ApiOperationBase
 {
-    public function __construct(AnetApiRequestType $request)
+    public function __construct(AnetApiRequestType $request, \net\authorize\util\Log $logger = null)
     {
         $responseType = 'net\authorize\api\contract\v1\UpdateCustomerPaymentProfileResponse';
-        parent::__construct($request, $responseType);
+        parent::__construct($request, $responseType, $logger);
     }
 
     protected function validateRequest()

--- a/lib/net/authorize/api/controller/UpdateCustomerProfileController.php
+++ b/lib/net/authorize/api/controller/UpdateCustomerProfileController.php
@@ -6,10 +6,10 @@ use net\authorize\api\controller\base\ApiOperationBase;
 
 class UpdateCustomerProfileController extends ApiOperationBase
 {
-    public function __construct(AnetApiRequestType $request)
+    public function __construct(AnetApiRequestType $request, \net\authorize\util\Log $logger = null)
     {
         $responseType = 'net\authorize\api\contract\v1\UpdateCustomerProfileResponse';
-        parent::__construct($request, $responseType);
+        parent::__construct($request, $responseType, $logger);
     }
 
     protected function validateRequest()

--- a/lib/net/authorize/api/controller/UpdateCustomerShippingAddressController.php
+++ b/lib/net/authorize/api/controller/UpdateCustomerShippingAddressController.php
@@ -6,10 +6,10 @@ use net\authorize\api\controller\base\ApiOperationBase;
 
 class UpdateCustomerShippingAddressController extends ApiOperationBase
 {
-    public function __construct(AnetApiRequestType $request)
+    public function __construct(AnetApiRequestType $request, \net\authorize\util\Log $logger = null)
     {
         $responseType = 'net\authorize\api\contract\v1\UpdateCustomerShippingAddressResponse';
-        parent::__construct($request, $responseType);
+        parent::__construct($request, $responseType, $logger);
     }
 
     protected function validateRequest()

--- a/lib/net/authorize/api/controller/UpdateSplitTenderGroupController.php
+++ b/lib/net/authorize/api/controller/UpdateSplitTenderGroupController.php
@@ -6,10 +6,10 @@ use net\authorize\api\controller\base\ApiOperationBase;
 
 class UpdateSplitTenderGroupController extends ApiOperationBase
 {
-    public function __construct(AnetApiRequestType $request)
+    public function __construct(AnetApiRequestType $request, \net\authorize\util\Log $logger = null)
     {
         $responseType = 'net\authorize\api\contract\v1\UpdateSplitTenderGroupResponse';
-        parent::__construct($request, $responseType);
+        parent::__construct($request, $responseType, $logger);
     }
 
     protected function validateRequest()

--- a/lib/net/authorize/api/controller/ValidateCustomerPaymentProfileController.php
+++ b/lib/net/authorize/api/controller/ValidateCustomerPaymentProfileController.php
@@ -6,10 +6,10 @@ use net\authorize\api\controller\base\ApiOperationBase;
 
 class ValidateCustomerPaymentProfileController extends ApiOperationBase
 {
-    public function __construct(AnetApiRequestType $request)
+    public function __construct(AnetApiRequestType $request, \net\authorize\util\Log $logger = null)
     {
         $responseType = 'net\authorize\api\contract\v1\ValidateCustomerPaymentProfileResponse';
-        parent::__construct($request, $responseType);
+        parent::__construct($request, $responseType, $logger);
     }
 
     protected function validateRequest()

--- a/lib/net/authorize/api/controller/base/ApiOperationBase.php
+++ b/lib/net/authorize/api/controller/base/ApiOperationBase.php
@@ -9,6 +9,7 @@ use GoetasWebservices\Xsd\XsdToPhpRuntime\Jms\Handler\XmlSchemaDateHandler;
 
 use \net\authorize\util\HttpClient;
 use \net\authorize\util\Helpers;
+use net\authorize\util\Log;
 use \net\authorize\util\LogFactory as LogFactory;
 
 
@@ -38,17 +39,22 @@ abstract class ApiOperationBase implements IApiOperation
      * @var \net\authorize\util\HttpClient;
      */
     public $httpClient = null;
-    private $logger = null;
+
+    /**
+     * @var \net\authorize\util\Log
+     */
+    private $logger;
+
     /**
      * Constructor.
      *
-     * @param \net\authorize\api\contract\v1\AnetApiRequestType $request ApiRequest to send
-     * @param string $responseType response type expected
-     * @throws InvalidArgumentException if invalid request
+     * @param \net\authorize\api\contract\v1\AnetApiRequestType $request      ApiRequest to send
+     * @param string                                            $responseType response type expected
+     * @param Log                                               $logger
      */
-    public function __construct(\net\authorize\api\contract\v1\AnetApiRequestType $request, $responseType)
+    public function __construct(\net\authorize\api\contract\v1\AnetApiRequestType $request, $responseType, Log $logger = null)
     {
-        $this->logger = LogFactory::getLog(get_class($this));
+        $this->logger = $logger ?: LogFactory::getLog( get_class( $this ) );
 
         if ( null == $request)
         {

--- a/lib/net/authorize/util/Log.php
+++ b/lib/net/authorize/util/Log.php
@@ -3,22 +3,6 @@ namespace net\authorize\util;
 
 use net\authorize\util\ANetSensitiveFields;
 
-define ("ANET_LOG_FILES_APPEND",true);
-
-define("ANET_LOG_DEBUG_PREFIX","DEBUG");
-define("ANET_LOG_INFO_PREFIX","INFO");
-define("ANET_LOG_WARN_PREFIX","WARN");
-define("ANET_LOG_ERROR_PREFIX","ERROR");
-
-//log levels
-define('ANET_LOG_DEBUG',1);
-define("ANET_LOG_INFO",2);
-define("ANET_LOG_WARN",3);
-define("ANET_LOG_ERROR",4);
-
-//set level
-define("ANET_LOG_LEVEL",ANET_LOG_DEBUG);
-
 /**
  * A class to implement logging.
  *
@@ -28,9 +12,29 @@ define("ANET_LOG_LEVEL",ANET_LOG_DEBUG);
 
 class Log
 {
-    private $sensitiveXmlTags = NULL;
+    const ANET_LOG_FILES_APPEND = true;
+
+    const ANET_LOG_DEBUG_PREFIX = "DEBUG";
+
+    const ANET_LOG_INFO_PREFIX  = "INFO";
+
+    const ANET_LOG_WARN_PREFIX  = "WARN";
+
+    const ANET_LOG_ERROR_PREFIX = "ERROR";
+
+    const ANET_LOG_DEBUG        = 1;
+
+    const ANET_LOG_INFO         = 2;
+
+    const ANET_LOG_WARN         = 3;
+
+    const ANET_LOG_ERROR        = 4;
+
+    private $sensitiveXmlTags = null;
+
     private $logFile = '';
-    private $logLevel = ANET_LOG_LEVEL;
+
+    private $logLevel = self::ANET_LOG_DEBUG;
 	
 	/**
 	* Takes a regex pattern (string) as argument and adds the forward slash delimiter.
@@ -271,26 +275,26 @@ class Log
 	
     public function debug($logMessage, $flags=FILE_APPEND)
     {
-        if(ANET_LOG_DEBUG >= $this->logLevel){
-            $this->log(ANET_LOG_DEBUG_PREFIX, $logMessage,$flags);
+        if(self::ANET_LOG_DEBUG >= $this->logLevel){
+            $this->log(self::ANET_LOG_DEBUG_PREFIX, $logMessage,$flags);
         }
     }
 	
     public function info($logMessage, $flags=FILE_APPEND){
-        if(ANET_LOG_INFO >= $this->logLevel) {
-            $this->log(ANET_LOG_INFO_PREFIX, $logMessage,$flags);
+        if(self::ANET_LOG_INFO >= $this->logLevel) {
+            $this->log(self::ANET_LOG_INFO_PREFIX, $logMessage,$flags);
         }
     }
 	
 	public function warn($logMessage, $flags=FILE_APPEND){
-        if(ANET_LOG_WARN >= $this->logLevel) {
-            $this->log(ANET_LOG_WARN_PREFIX, $logMessage,$flags);
+        if(self::ANET_LOG_WARN >= $this->logLevel) {
+            $this->log(self::ANET_LOG_WARN_PREFIX, $logMessage,$flags);
         }
     }
 	
     public function error($logMessage, $flags=FILE_APPEND){
-        if(ANET_LOG_ERROR >= $this->logLevel) {
-            $this->log(ANET_LOG_ERROR_PREFIX, $logMessage,$flags);
+        if(self::ANET_LOG_ERROR >= $this->logLevel) {
+            $this->log(self::ANET_LOG_ERROR_PREFIX, $logMessage,$flags);
         }
     }
 	
@@ -309,26 +313,26 @@ class Log
 	
 	public function debugFormat($format, $args=array(),  $flags=FILE_APPEND)
     {
-        if(ANET_LOG_DEBUG >= $this->logLevel){
-            $this->logFormat(ANET_LOG_DEBUG_PREFIX, $format, $args , $flags);
+        if(self::ANET_LOG_DEBUG >= $this->logLevel){
+            $this->logFormat( self::ANET_LOG_DEBUG_PREFIX, $format, $args , $flags);
         }
     }
 	
 	public function infoFormat($format, $args=array(),  $flags=FILE_APPEND){
-        if(ANET_LOG_INFO >= $this->logLevel) {
-            $this->logFormat(ANET_LOG_INFO_PREFIX, $format, $args , $flags);
+        if(self::ANET_LOG_INFO >= $this->logLevel) {
+            $this->logFormat( self::ANET_LOG_INFO_PREFIX, $format, $args , $flags);
         }
     }
 	
 	public function warnFormat($format, $args=array(),  $flags=FILE_APPEND){
-        if(ANET_LOG_WARN >= $this->logLevel) {
-            $this->logFormat(ANET_LOG_WARN_PREFIX, $format, $args , $flags);
+        if(self::ANET_LOG_WARN >= $this->logLevel) {
+            $this->logFormat(self::ANET_LOG_WARN_PREFIX, $format, $args , $flags);
         }
     }
 	
     public function errorFormat($format, $args=array(),  $flags=FILE_APPEND){
-        if(ANET_LOG_ERROR >= $this->logLevel) {
-			$this->logFormat(ANET_LOG_ERROR_PREFIX, $format, $args , $flags);
+        if(self::ANET_LOG_ERROR >= $this->logLevel) {
+			$this->logFormat(self::ANET_LOG_ERROR_PREFIX, $format, $args , $flags);
         }
     }
 


### PR DESCRIPTION
Problem:
There is currently no way to set the log level of the logger class

Solution:
Allow for Log class to be injected into each controller. If no Log class is injected then the Log factory will be used

Notable changes:
 - All globally defined variables have been moved into the class scope as public constants. This will prevent implementers of this library from defining the global variables and raising PHP notices. This also allows for any IDE to pick up on the public visibility and give the constants as recommended selections.
 - `$logger` should never be null

Fixes #186 