### PR TITLE
Added LIBXML_NOWARNING to simplexml_load_string calls to suppress PHP…

### DIFF
--- a/lib/AuthorizeNetCP.php
+++ b/lib/AuthorizeNetCP.php
@@ -119,7 +119,7 @@ class AuthorizeNetCP_Response extends AuthorizeNetResponse
             // If it's an XML response
             if (substr($response, 0, 5) == "<?xml") {
                 
-                $this->xml = @simplexml_load_string($response);
+                $this->xml = @simplexml_load_string($response, 'SimpleXMLElement', LIBXML_NOWARNING);
                 // Set all fields
                 $this->version              = array_pop(array_slice(explode('"', $response), 1,1));
                 $this->response_code        = (string)$this->xml->ResponseCode;

--- a/lib/shared/AuthorizeNetXMLResponse.php
+++ b/lib/shared/AuthorizeNetXMLResponse.php
@@ -26,10 +26,10 @@ class AuthorizeNetXMLResponse
     {
         $this->response = $response;
         if ($response) {
-            $this->xml = @simplexml_load_string($response);
+            $this->xml = @simplexml_load_string($response,'SimpleXMLElement', LIBXML_NOWARNING);
             
             // Remove namespaces for use with XPath.
-            $this->xpath_xml = @simplexml_load_string(preg_replace('/ xmlns:xsi[^>]+/','',$response));
+            $this->xpath_xml = @simplexml_load_string(preg_replace('/ xmlns:xsi[^>]+/','',$response),'SimpleXMLElement', LIBXML_NOWARNING);
         }
     }
     


### PR DESCRIPTION
In PHP 7 the absence of a protocol prefix to an XML namespace generates a warning:

> PHP Warning·simplexml_load_string(): namespace warning : xmlns: URI AnetApi/xml/v1/schema/AnetApiSchema.xsd is not absolute
