### PR TITLE
Escape line item values, fixes #244

### DIFF
--- a/lib/AuthorizeNetAIM.php
+++ b/lib/AuthorizeNetAIM.php
@@ -269,7 +269,7 @@ class AuthorizeNetAIM extends AuthorizeNetRequest
         $line_item = "";
         $delimiter = "";
         foreach (func_get_args() as $key => $value) {
-            $line_item .= $delimiter . $value;
+            $line_item .= $delimiter . preg_replace('/|/', '_', $value);
             $delimiter = "<|>";
         }
         $this->_additional_line_items[] = $line_item;


### PR DESCRIPTION
Reference: https://www.authorize.net/content/dam/authorize/documents/AIM_guide.pdf version June 2016 page 39.

Fixes input sanitization issue #244.