### PR TITLE
Add "includeIssuerInfo" parameter to getCustomerProfile and getCustomerPaymentProfile

### DIFF
--- a/lib/AuthorizeNetCIM.php
+++ b/lib/AuthorizeNetCIM.php
@@ -181,10 +181,17 @@ class AuthorizeNetCIM extends AuthorizeNetRequest
      *
      * @return AuthorizeNetCIM_Response
      */
-    public function getCustomerProfile($customerProfileId)
+    public function getCustomerProfile($customerProfileId, $unmaskExpirationDate = false, $includeIssuerInfo = false)
     {
         $this->_constructXml("getCustomerProfileRequest");
         $this->_xml->addChild("customerProfileId", $customerProfileId);
+        if ( $unmaskExpirationDate ) {
+            $this->_xml->addChild("unmaskExpirationDate", true);
+        }
+        if ( $includeIssuerInfo ) {
+            $this->_xml->addChild("includeIssuerInfo", true);
+        }
+
         return $this->_sendRequest();
     }
     
@@ -197,13 +204,16 @@ class AuthorizeNetCIM extends AuthorizeNetRequest
      *
      * @return AuthorizeNetCIM_Response
      */
-    public function getCustomerPaymentProfile($customerProfileId, $customerPaymentProfileId, $unmaskExpirationDate = false)
+    public function getCustomerPaymentProfile($customerProfileId, $customerPaymentProfileId, $unmaskExpirationDate = false, $includeIssuerInfo = false)
     {
         $this->_constructXml("getCustomerPaymentProfileRequest");
         $this->_xml->addChild("customerProfileId", $customerProfileId);
         $this->_xml->addChild("customerPaymentProfileId", $customerPaymentProfileId);
         if ( $unmaskExpirationDate ) {
             $this->_xml->addChild("unmaskExpirationDate", true);
+        }
+        if ( $includeIssuerInfo ) {
+            $this->_xml->addChild("includeIssuerInfo", true);
         }
 
         return $this->_sendRequest();

--- a/lib/net/authorize/api/contract/v1/CreditCardMaskedType.php
+++ b/lib/net/authorize/api/contract/v1/CreditCardMaskedType.php
@@ -22,6 +22,11 @@ class CreditCardMaskedType
     private $expirationDate = null;
 
     /**
+     * @property string $issuerNumber
+     */
+    private $issuerNumber = null;
+
+    /**
      * @property string $cardType
      */
     private $cardType = null;
@@ -72,6 +77,28 @@ class CreditCardMaskedType
     public function setExpirationDate($expirationDate)
     {
         $this->expirationDate = $expirationDate;
+        return $this;
+    }
+
+    /**
+     * Gets as issuerNumber
+     *
+     * @return string
+     */
+    public function getIssuerNumber()
+    {
+        return $this->issuerNumber;
+    }
+
+    /**
+     * Sets a new issuerNumber
+     *
+     * @param string $issuerNumber
+     * @return self
+     */
+    public function setIssuerNumber($issuerNumber)
+    {
+        $this->issuerNumber = $issuerNumber;
         return $this;
     }
 

--- a/lib/net/authorize/api/contract/v1/CustomerProfileMaskedType.php
+++ b/lib/net/authorize/api/contract/v1/CustomerProfileMaskedType.php
@@ -12,26 +12,6 @@ class CustomerProfileMaskedType extends CustomerProfileExType
 {
 
     /**
-     * @property string $customerProfileId
-     */
-    private $customerProfileId = null;
-    
-    /**
-     * @property string $merchantCustomerId
-     */
-    private $merchantCustomerId = null;
-
-    /**
-     * @property string $description
-     */
-    private $description = null;
-
-    /**
-     * @property string $email
-     */
-    private $email = null;
-
-    /**
      * @property \net\authorize\api\contract\v1\CustomerPaymentProfileMaskedType[]
      * $paymentProfiles
      */
@@ -41,94 +21,6 @@ class CustomerProfileMaskedType extends CustomerProfileExType
      * @property \net\authorize\api\contract\v1\CustomerAddressExType[] $shipToList
      */
     private $shipToList = null;
-
-    /**
-     * Gets as customerProfileId
-     *
-     * @return string
-     */
-    public function getCustomerProfileId()
-    {
-        return $this->customerProfileId;
-    }
-
-    /**
-     * Sets a new customerProfileId
-     *
-     * @param string $customerProfileId
-     * @return self
-     */
-    public function setCustomerProfileId($customerProfileId)
-    {
-        $this->customerProfileId = $customerProfileId;
-        return $this;
-    }
-
-    /**
-     * Gets as merchantCustomerId
-     *
-     * @return string
-     */
-    public function getMerchantCustomerId()
-    {
-        return $this->merchantCustomerId;
-    }
-
-    /**
-     * Sets a new merchantCustomerId
-     *
-     * @param string $merchantCustomerId
-     * @return self
-     */
-    public function setMerchantCustomerId($merchantCustomerId)
-    {
-        $this->merchantCustomerId = $merchantCustomerId;
-        return $this;
-    }
-
-    /**
-     * Gets as description
-     *
-     * @return string
-     */
-    public function getDescription()
-    {
-        return $this->description;
-    }
-
-    /**
-     * Sets a new description
-     *
-     * @param string $description
-     * @return self
-     */
-    public function setDescription($description)
-    {
-        $this->description = $description;
-        return $this;
-    }    
-
-    /**
-     * Gets as email
-     *
-     * @return string
-     */
-    public function getEmail()
-    {
-        return $this->email;
-    }
-
-    /**
-     * Sets a new email
-     *
-     * @param string $email
-     * @return self
-     */
-    public function setEmail($email)
-    {
-        $this->email = $email;
-        return $this;
-    }    
 
     /**
      * Adds as paymentProfiles

--- a/lib/net/authorize/api/contract/v1/CustomerProfileMaskedType.php
+++ b/lib/net/authorize/api/contract/v1/CustomerProfileMaskedType.php
@@ -53,6 +53,18 @@ class CustomerProfileMaskedType extends CustomerProfileExType
     }
 
     /**
+     * Sets a new customerProfileId
+     *
+     * @param string $customerProfileId
+     * @return self
+     */
+    public function setCustomerProfileId($customerProfileId)
+    {
+        $this->customerProfileId = $customerProfileId;
+        return $this;
+    }
+
+    /**
      * Gets as merchantCustomerId
      *
      * @return string
@@ -60,6 +72,18 @@ class CustomerProfileMaskedType extends CustomerProfileExType
     public function getMerchantCustomerId()
     {
         return $this->merchantCustomerId;
+    }
+
+    /**
+     * Sets a new merchantCustomerId
+     *
+     * @param string $merchantCustomerId
+     * @return self
+     */
+    public function setMerchantCustomerId($merchantCustomerId)
+    {
+        $this->merchantCustomerId = $merchantCustomerId;
+        return $this;
     }
 
     /**
@@ -73,6 +97,18 @@ class CustomerProfileMaskedType extends CustomerProfileExType
     }
 
     /**
+     * Sets a new description
+     *
+     * @param string $description
+     * @return self
+     */
+    public function setDescription($description)
+    {
+        $this->description = $description;
+        return $this;
+    }    
+
+    /**
      * Gets as email
      *
      * @return string
@@ -81,6 +117,18 @@ class CustomerProfileMaskedType extends CustomerProfileExType
     {
         return $this->email;
     }
+
+    /**
+     * Sets a new email
+     *
+     * @param string $email
+     * @return self
+     */
+    public function setEmail($email)
+    {
+        $this->email = $email;
+        return $this;
+    }    
 
     /**
      * Adds as paymentProfiles

--- a/lib/net/authorize/api/contract/v1/CustomerProfileMaskedType.php
+++ b/lib/net/authorize/api/contract/v1/CustomerProfileMaskedType.php
@@ -12,6 +12,26 @@ class CustomerProfileMaskedType extends CustomerProfileExType
 {
 
     /**
+     * @property string $customerProfileId
+     */
+    private $customerProfileId = null;
+    
+    /**
+     * @property string $merchantCustomerId
+     */
+    private $merchantCustomerId = null;
+
+    /**
+     * @property string $description
+     */
+    private $description = null;
+
+    /**
+     * @property string $email
+     */
+    private $email = null;
+
+    /**
      * @property \net\authorize\api\contract\v1\CustomerPaymentProfileMaskedType[]
      * $paymentProfiles
      */
@@ -21,6 +41,46 @@ class CustomerProfileMaskedType extends CustomerProfileExType
      * @property \net\authorize\api\contract\v1\CustomerAddressExType[] $shipToList
      */
     private $shipToList = null;
+
+    /**
+     * Gets as customerProfileId
+     *
+     * @return string
+     */
+    public function getCustomerProfileId()
+    {
+        return $this->customerProfileId;
+    }
+
+    /**
+     * Gets as merchantCustomerId
+     *
+     * @return string
+     */
+    public function getMerchantCustomerId()
+    {
+        return $this->merchantCustomerId;
+    }
+
+    /**
+     * Gets as description
+     *
+     * @return string
+     */
+    public function getDescription()
+    {
+        return $this->description;
+    }
+
+    /**
+     * Gets as email
+     *
+     * @return string
+     */
+    public function getEmail()
+    {
+        return $this->email;
+    }
 
     /**
      * Adds as paymentProfiles

--- a/lib/net/authorize/api/contract/v1/GetCustomerPaymentProfileRequest.php
+++ b/lib/net/authorize/api/contract/v1/GetCustomerPaymentProfileRequest.php
@@ -24,6 +24,11 @@ class GetCustomerPaymentProfileRequest extends ANetApiRequestType
     private $unmaskExpirationDate = null;
 
     /**
+     * @property boolean $includeIssuerInfo
+     */
+    private $includeIssuerInfo = null;
+
+    /**
      * Gets as customerProfileId
      *
      * @return string
@@ -86,6 +91,28 @@ class GetCustomerPaymentProfileRequest extends ANetApiRequestType
     public function setUnmaskExpirationDate($unmaskExpirationDate)
     {
         $this->unmaskExpirationDate = $unmaskExpirationDate;
+        return $this;
+    }
+
+    /**
+     * Gets as includeIssuerInfo
+     *
+     * @return boolean
+     */
+    public function getIncludeIssuerInfo()
+    {
+        return $this->includeIssuerInfo;
+    }
+
+    /**
+     * Sets a new includeIssuerInfo
+     *
+     * @param boolean $includeIssuerInfo
+     * @return self
+     */
+    public function setIncludeIssuerInfo($includeIssuerInfo)
+    {
+        $this->includeIssuerInfo = $includeIssuerInfo;
         return $this;
     }
 

--- a/lib/net/authorize/api/contract/v1/GetCustomerProfileRequest.php
+++ b/lib/net/authorize/api/contract/v1/GetCustomerProfileRequest.php
@@ -29,6 +29,11 @@ class GetCustomerProfileRequest extends ANetApiRequestType
     private $unmaskExpirationDate = null;
 
     /**
+     * @property boolean $includeIssuerInfo
+     */
+    private $includeIssuerInfo = null;
+
+    /**
      * Gets as customerProfileId
      *
      * @return string
@@ -113,6 +118,28 @@ class GetCustomerProfileRequest extends ANetApiRequestType
     public function setUnmaskExpirationDate($unmaskExpirationDate)
     {
         $this->unmaskExpirationDate = $unmaskExpirationDate;
+        return $this;
+    }
+
+    /**
+     * Gets as includeIssuerInfo
+     *
+     * @return boolean
+     */
+    public function getIncludeIssuerInfo()
+    {
+        return $this->includeIssuerInfo;
+    }
+
+    /**
+     * Sets a new includeIssuerInfo
+     *
+     * @param boolean $includeIssuerInfo
+     * @return self
+     */
+    public function setIncludeIssuerInfo($includeIssuerInfo)
+    {
+        $this->includeIssuerInfo = $includeIssuerInfo;
         return $this;
     }
 

--- a/lib/net/authorize/api/yml/v1/CreditCardMaskedType.yml
+++ b/lib/net/authorize/api/yml/v1/CreditCardMaskedType.yml
@@ -20,6 +20,16 @@ net\authorize\api\contract\v1\CreditCardMaskedType:
                 getter: getExpirationDate
                 setter: setExpirationDate
             type: string
+        issuerNumber:
+            expose: true
+            access_type: public_method
+            serialized_name: issuerNumber
+            xml_element:
+                namespace: AnetApi/xml/v1/schema/AnetApiSchema.xsd
+            accessor:
+                getter: getIssuerNumber
+                setter: setIssuerNumber
+            type: string
         cardType:
             expose: true
             access_type: public_method

--- a/lib/net/authorize/api/yml/v1/CustomerProfileMaskedType.yml
+++ b/lib/net/authorize/api/yml/v1/CustomerProfileMaskedType.yml
@@ -1,5 +1,45 @@
 net\authorize\api\contract\v1\CustomerProfileMaskedType:
     properties:
+        customerProfileId:
+            expose: true
+            access_type: public_method
+            serialized_name: customerProfileId
+            xml_element:
+                namespace: AnetApi/xml/v1/schema/AnetApiSchema.xsd
+            accessor:
+                getter: getCustomerProfileId
+                setter: setCustomerProfileId
+            type: string
+        merchantCustomerId:
+            expose: true
+            access_type: public_method
+            serialized_name: merchantCustomerId
+            xml_element:
+                namespace: AnetApi/xml/v1/schema/AnetApiSchema.xsd
+            accessor:
+                getter: getMerchantCustomerId
+                setter: setMerchantCustomerId
+            type: string
+        description:
+            expose: true
+            access_type: public_method
+            serialized_name: description
+            xml_element:
+                namespace: AnetApi/xml/v1/schema/AnetApiSchema.xsd
+            accessor:
+                getter: getDescription
+                setter: setDescription
+            type: string
+        email:
+            expose: true
+            access_type: public_method
+            serialized_name: email
+            xml_element:
+                namespace: AnetApi/xml/v1/schema/AnetApiSchema.xsd
+            accessor:
+                getter: getEmail
+                setter: setEmail
+            type: string
         paymentProfiles:
             expose: true
             access_type: public_method

--- a/lib/net/authorize/api/yml/v1/CustomerProfileMaskedType.yml
+++ b/lib/net/authorize/api/yml/v1/CustomerProfileMaskedType.yml
@@ -1,45 +1,5 @@
 net\authorize\api\contract\v1\CustomerProfileMaskedType:
     properties:
-        customerProfileId:
-            expose: true
-            access_type: public_method
-            serialized_name: customerProfileId
-            xml_element:
-                namespace: AnetApi/xml/v1/schema/AnetApiSchema.xsd
-            accessor:
-                getter: getCustomerProfileId
-                setter: setCustomerProfileId
-            type: string
-        merchantCustomerId:
-            expose: true
-            access_type: public_method
-            serialized_name: merchantCustomerId
-            xml_element:
-                namespace: AnetApi/xml/v1/schema/AnetApiSchema.xsd
-            accessor:
-                getter: getMerchantCustomerId
-                setter: setMerchantCustomerId
-            type: string
-        description:
-            expose: true
-            access_type: public_method
-            serialized_name: description
-            xml_element:
-                namespace: AnetApi/xml/v1/schema/AnetApiSchema.xsd
-            accessor:
-                getter: getDescription
-                setter: setDescription
-            type: string
-        email:
-            expose: true
-            access_type: public_method
-            serialized_name: email
-            xml_element:
-                namespace: AnetApi/xml/v1/schema/AnetApiSchema.xsd
-            accessor:
-                getter: getEmail
-                setter: setEmail
-            type: string
         paymentProfiles:
             expose: true
             access_type: public_method

--- a/lib/net/authorize/api/yml/v1/GetCustomerPaymentProfileRequest.yml
+++ b/lib/net/authorize/api/yml/v1/GetCustomerPaymentProfileRequest.yml
@@ -32,3 +32,13 @@ net\authorize\api\contract\v1\GetCustomerPaymentProfileRequest:
                 getter: getUnmaskExpirationDate
                 setter: setUnmaskExpirationDate
             type: boolean
+        includeIssuerInfo:
+            expose: true
+            access_type: public_method
+            serialized_name: includeIssuerInfo
+            xml_element:
+                namespace: AnetApi/xml/v1/schema/AnetApiSchema.xsd
+            accessor:
+                getter: getIncludeIssuerInfo
+                setter: setIncludeIssuerInfo
+            type: boolean

--- a/lib/net/authorize/api/yml/v1/GetCustomerProfileRequest.yml
+++ b/lib/net/authorize/api/yml/v1/GetCustomerProfileRequest.yml
@@ -42,3 +42,13 @@ net\authorize\api\contract\v1\GetCustomerProfileRequest:
                 getter: getUnmaskExpirationDate
                 setter: setUnmaskExpirationDate
             type: boolean
+        includeIssuerInfo:
+            expose: true
+            access_type: public_method
+            serialized_name: includeIssuerInfo
+            xml_element:
+                namespace: AnetApi/xml/v1/schema/AnetApiSchema.xsd
+            accessor:
+                getter: getIncludeIssuerInfo
+                setter: setIncludeIssuerInfo
+            type: boolean


### PR DESCRIPTION
The API allows for the parameter "includeIssuerInfo" to be passed which exposes the IIN in the response. This library currently does not include that parameter (see #261 ). This pull request adds that capability.