### PR TITLE
Add includeTransactions in ARBGetSubscription API

### DIFF
--- a/classmap.php
+++ b/classmap.php
@@ -261,6 +261,7 @@ return array(
     'net\authorize\api\contract\v1\ARBGetSubscriptionStatusResponse' => $libDir . 'net/authorize/api/contract/v1/ARBGetSubscriptionStatusResponse.php',
     'net\authorize\api\contract\v1\ARBSubscriptionMaskedType' => $libDir . 'net/authorize/api/contract/v1/ARBSubscriptionMaskedType.php',
     'net\authorize\api\contract\v1\ARBSubscriptionType' => $libDir . 'net/authorize/api/contract/v1/ARBSubscriptionType.php',
+    'net\authorize\api\contract\v1\ArbTransactionType' => $libDir . 'net/authorize/api/contract/v1/ArbTransactionType.php',
     'net\authorize\api\contract\v1\ARBUpdateSubscriptionRequest' => $libDir . 'net/authorize/api/contract/v1/ARBUpdateSubscriptionRequest.php',
     'net\authorize\api\contract\v1\ARBUpdateSubscriptionResponse' => $libDir . 'net/authorize/api/contract/v1/ARBUpdateSubscriptionResponse.php',
     'net\authorize\api\contract\v1\ArrayOfSettingType' => $libDir . 'net/authorize/api/contract/v1/ArrayOfSettingType.php',

--- a/lib/net/authorize/api/contract/v1/ARBGetSubscriptionRequest.php
+++ b/lib/net/authorize/api/contract/v1/ARBGetSubscriptionRequest.php
@@ -14,6 +14,11 @@ class ARBGetSubscriptionRequest extends ANetApiRequestType
     private $subscriptionId = null;
 
     /**
+     * @property boolean $includeTransactions
+     */
+    private $includeTransactions = null;
+
+    /**
      * Gets as subscriptionId
      *
      * @return string
@@ -32,6 +37,28 @@ class ARBGetSubscriptionRequest extends ANetApiRequestType
     public function setSubscriptionId($subscriptionId)
     {
         $this->subscriptionId = $subscriptionId;
+        return $this;
+    }
+
+    /**
+     * Gets as includeTransactions
+     *
+     * @return boolean
+     */
+    public function getIncludeTransactions()
+    {
+        return $this->includeTransactions;
+    }
+
+    /**
+     * Sets a new includeTransactions
+     *
+     * @param boolean $includeTransactions
+     * @return self
+     */
+    public function setIncludeTransactions($includeTransactions)
+    {
+        $this->includeTransactions = $includeTransactions;
         return $this;
     }
 

--- a/lib/net/authorize/api/contract/v1/ARBSubscriptionMaskedType.php
+++ b/lib/net/authorize/api/contract/v1/ARBSubscriptionMaskedType.php
@@ -48,6 +48,11 @@ class ARBSubscriptionMaskedType
     private $order = null;
 
     /**
+     * @property \net\authorize\api\contract\v1\ArbTransactionType[] $arbTransactions
+     */
+    private $arbTransactions = null;
+
+    /**
      * Gets as name
      *
      * @return string
@@ -198,6 +203,62 @@ class ARBSubscriptionMaskedType
     public function setOrder(\net\authorize\api\contract\v1\OrderType $order)
     {
         $this->order = $order;
+        return $this;
+    }
+
+    /**
+     * Adds as arbTransaction
+     *
+     * @return self
+     * @param \net\authorize\api\contract\v1\ArbTransactionType $arbTransaction
+     */
+    public function addToArbTransactions(\net\authorize\api\contract\v1\ArbTransactionType $arbTransaction)
+    {
+        $this->arbTransactions[] = $arbTransaction;
+        return $this;
+    }
+
+    /**
+     * isset arbTransactions
+     *
+     * @param scalar $index
+     * @return boolean
+     */
+    public function issetArbTransactions($index)
+    {
+        return isset($this->arbTransactions[$index]);
+    }
+
+    /**
+     * unset arbTransactions
+     *
+     * @param scalar $index
+     * @return void
+     */
+    public function unsetArbTransactions($index)
+    {
+        unset($this->arbTransactions[$index]);
+    }
+
+    /**
+     * Gets as arbTransactions
+     *
+     * @return \net\authorize\api\contract\v1\ArbTransactionType[]
+     */
+    public function getArbTransactions()
+    {
+        return $this->arbTransactions;
+    }
+
+    /**
+     * Sets a new arbTransactions
+     *
+     * @param \net\authorize\api\contract\v1\ArbTransactionType[] $arbTransactions
+     * @return self
+     */
+    public function setArbTransactions(array $arbTransactions)
+    {
+        $this->arbTransactions = $arbTransactions;
         return $this;
     }
 

--- a/lib/net/authorize/api/contract/v1/ArbTransactionType.php
+++ b/lib/net/authorize/api/contract/v1/ArbTransactionType.php
@@ -1,0 +1,151 @@
+<?php
+
+namespace net\authorize\api\contract\v1;
+
+/**
+ * Class representing ArbTransactionType
+ *
+ *
+ * XSD Type: arbTransaction
+ */
+class ArbTransactionType
+{
+
+    /**
+     * @property string $transId
+     */
+    private $transId = null;
+
+    /**
+     * @property string $response
+     */
+    private $response = null;
+
+    /**
+     * @property \DateTime $submitTimeUTC
+     */
+    private $submitTimeUTC = null;
+
+    /**
+     * @property integer $payNum
+     */
+    private $payNum = null;
+
+    /**
+     * @property integer $attemptNum
+     */
+    private $attemptNum = null;
+
+    /**
+     * Gets as transId
+     *
+     * @return string
+     */
+    public function getTransId()
+    {
+        return $this->transId;
+    }
+
+    /**
+     * Sets a new transId
+     *
+     * @param string $transId
+     * @return self
+     */
+    public function setTransId($transId)
+    {
+        $this->transId = $transId;
+        return $this;
+    }
+
+    /**
+     * Gets as response
+     *
+     * @return string
+     */
+    public function getResponse()
+    {
+        return $this->response;
+    }
+
+    /**
+     * Sets a new response
+     *
+     * @param string $response
+     * @return self
+     */
+    public function setResponse($response)
+    {
+        $this->response = $response;
+        return $this;
+    }
+
+    /**
+     * Gets as submitTimeUTC
+     *
+     * @return \DateTime
+     */
+    public function getSubmitTimeUTC()
+    {
+        return $this->submitTimeUTC;
+    }
+
+    /**
+     * Sets a new submitTimeUTC
+     *
+     * @param \DateTime $submitTimeUTC
+     * @return self
+     */
+    public function setSubmitTimeUTC(\DateTime $submitTimeUTC)
+    {
+        $this->submitTimeUTC = $submitTimeUTC;
+        return $this;
+    }
+
+    /**
+     * Gets as payNum
+     *
+     * @return integer
+     */
+    public function getPayNum()
+    {
+        return $this->payNum;
+    }
+
+    /**
+     * Sets a new payNum
+     *
+     * @param integer $payNum
+     * @return self
+     */
+    public function setPayNum($payNum)
+    {
+        $this->payNum = $payNum;
+        return $this;
+    }
+
+    /**
+     * Gets as attemptNum
+     *
+     * @return integer
+     */
+    public function getAttemptNum()
+    {
+        return $this->attemptNum;
+    }
+
+    /**
+     * Sets a new attemptNum
+     *
+     * @param integer $attemptNum
+     * @return self
+     */
+    public function setAttemptNum($attemptNum)
+    {
+        $this->attemptNum = $attemptNum;
+        return $this;
+    }
+
+
+}
+

--- a/lib/net/authorize/api/yml/v1/ARBGetSubscriptionRequest.yml
+++ b/lib/net/authorize/api/yml/v1/ARBGetSubscriptionRequest.yml
@@ -12,3 +12,13 @@ net\authorize\api\contract\v1\ARBGetSubscriptionRequest:
                 getter: getSubscriptionId
                 setter: setSubscriptionId
             type: string
+        includeTransactions:
+            expose: true
+            access_type: public_method
+            serialized_name: includeTransactions
+            xml_element:
+                namespace: AnetApi/xml/v1/schema/AnetApiSchema.xsd
+            accessor:
+                getter: getIncludeTransactions
+                setter: setIncludeTransactions
+            type: boolean

--- a/lib/net/authorize/api/yml/v1/ARBSubscriptionMaskedType.yml
+++ b/lib/net/authorize/api/yml/v1/ARBSubscriptionMaskedType.yml
@@ -70,3 +70,18 @@ net\authorize\api\contract\v1\ARBSubscriptionMaskedType:
                 getter: getOrder
                 setter: setOrder
             type: net\authorize\api\contract\v1\OrderType
+        arbTransactions:
+            expose: true
+            access_type: public_method
+            serialized_name: arbTransactions
+            xml_element:
+                namespace: AnetApi/xml/v1/schema/AnetApiSchema.xsd
+            accessor:
+                getter: getArbTransactions
+                setter: setArbTransactions
+            type: array<net\authorize\api\contract\v1\ArbTransactionType>
+            xml_list:
+                inline: false
+                skip_when_empty: true
+                entry_name: arbTransaction
+                namespace: AnetApi/xml/v1/schema/AnetApiSchema.xsd

--- a/lib/net/authorize/api/yml/v1/ArbTransactionType.yml
+++ b/lib/net/authorize/api/yml/v1/ArbTransactionType.yml
@@ -1,0 +1,52 @@
+net\authorize\api\contract\v1\ArbTransactionType:
+    properties:
+        transId:
+            expose: true
+            access_type: public_method
+            serialized_name: transId
+            xml_element:
+                namespace: AnetApi/xml/v1/schema/AnetApiSchema.xsd
+            accessor:
+                getter: getTransId
+                setter: setTransId
+            type: string
+        response:
+            expose: true
+            access_type: public_method
+            serialized_name: response
+            xml_element:
+                namespace: AnetApi/xml/v1/schema/AnetApiSchema.xsd
+            accessor:
+                getter: getResponse
+                setter: setResponse
+            type: string
+        submitTimeUTC:
+            expose: true
+            access_type: public_method
+            serialized_name: submitTimeUTC
+            xml_element:
+                namespace: AnetApi/xml/v1/schema/AnetApiSchema.xsd
+            accessor:
+                getter: getSubmitTimeUTC
+                setter: setSubmitTimeUTC
+            type: GoetasWebservices\Xsd\XsdToPhp\XMLSchema\DateTime
+        payNum:
+            expose: true
+            access_type: public_method
+            serialized_name: payNum
+            xml_element:
+                namespace: AnetApi/xml/v1/schema/AnetApiSchema.xsd
+            accessor:
+                getter: getPayNum
+                setter: setPayNum
+            type: integer
+        attemptNum:
+            expose: true
+            access_type: public_method
+            serialized_name: attemptNum
+            xml_element:
+                namespace: AnetApi/xml/v1/schema/AnetApiSchema.xsd
+            accessor:
+                getter: getAttemptNum
+                setter: setAttemptNum
+            type: integer

--- a/scripts/composer.json.masterUpdate
+++ b/scripts/composer.json.masterUpdate
@@ -1,0 +1,27 @@
+{
+    "name": "authorizenet/authorizenet",
+    "type": "library",
+    "description": "Official PHP SDK for Authorize.Net",
+    "keywords": ["authorizenet", "authorize.net", "payment", "ecommerce"],
+    "license": "proprietary",
+    "homepage": "http://developer.authorize.net",
+    "require": {
+        "php": ">=5.6",
+        "ext-curl": "*",
+        "ext-json": "*",
+        "ext-simplexml": "*",
+        "ext-xmlwriter": "*",
+        "goetas-webservices/xsd2php-runtime":"^0.2.2",
+        "goetas/xsd2php": "^2.0"
+    },
+    "require-dev": {
+        "phpunit/phpunit": "~4.0",
+        "phpmd/phpmd": "~2.0"
+    },
+    "autoload": {
+        "classmap": ["lib"]
+    },
+    "autoload-dev": {
+        "classmap": ["tests"]
+    }   
+}


### PR DESCRIPTION
Request and response changes for adding **_includeTransactions_** in **ARBGetSubscription API** for ARB subscriptions.

Tested change by running modified sample codes for _get-subscription-list.php_ and _get-subscription.php_ for a subscription with some past transactions.