### PR TITLE
Add the ability to configure the CA PEM file location

### DIFF
--- a/lib/net/authorize/util/HttpClient.php
+++ b/lib/net/authorize/util/HttpClient.php
@@ -77,7 +77,11 @@ class HttpClient
         $this->logger->info(sprintf("Request to AnetApi: \n%s", $xmlRequest));
 
         if ($this->VERIFY_PEER) {
-            curl_setopt($curl_request, CURLOPT_CAINFO, dirname(dirname(__FILE__)) . '/../../ssl/cert.pem');
+            if (defined('AUTHORIZENET_CA_PEM_FILE')) {
+                curl_setopt($curl_request, CURLOPT_CAINFO, AUTHORIZENET_CA_PEM_FILE);
+            } else {
+                curl_setopt($curl_request, CURLOPT_CAINFO, dirname(dirname(__FILE__)) . '/../../ssl/cert.pem');
+            }
         } else {
             $this->logger->error("Invalid SSL option for the request");
             return false;


### PR DESCRIPTION
Here is my proposal for: https://github.com/AuthorizeNet/sdk-php/issues/298

By using the same pattern as the log file where you can define a constant `AUTHORIZENET_CA_PEM_FILE` which provides the location of the log file.

Will allow developers to define the path in their implementation, so the pem can configured for production or development environments, and also allow for the pem to be swapped out quickly if in future the endpoint's ssl changes and the CA won't validate.