### PR TITLE
Fix for `Class SampleCode Constants not found` issue

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "phpmd/phpmd": "~2.0"
     },
     "autoload": {
-        "classmap": ["lib"]
+        "classmap": ["lib", "constants"]
     },
     "autoload-dev": {
         "classmap": ["tests"]

--- a/constants/SampleCodeConstants.php
+++ b/constants/SampleCodeConstants.php
@@ -1,0 +1,9 @@
+<?php
+class SampleCodeConstants
+{
+	//merchant credentials
+	const MERCHANT_LOGIN_ID = "5KP3u95bQpv";
+	const MERCHANT_TRANSACTION_KEY = "346HZ32z3fP4hTG2";
+}
+?>
+


### PR DESCRIPTION
This fix is for Class-SampleCode-Constants-not-found issue reported by developers on https://community.developer.authorize.net/t5/Integration-and-Testing/Class-SampleCode-Constants-not-found/td-p/55328.