### PR TITLE
Fixed docs error for magento 2.3.x usage.

### DIFF
--- a/lib/net/authorize/api/contract/v1/ANetApiRequestType.php
+++ b/lib/net/authorize/api/contract/v1/ANetApiRequestType.php
@@ -95,7 +95,11 @@ class ANetApiRequestType implements \JsonSerializable
     }
 
 
-    // Json Serialize Code
+    /**
+     * Json Serialize Code
+     *
+     * @return array|mixed
+     */
     public function jsonSerialize(){
         $values = array_filter((array)get_object_vars($this),
         function ($val){
@@ -129,8 +133,15 @@ class ANetApiRequestType implements \JsonSerializable
             return array_merge(parent::jsonSerialize(), $values);
         }
     }
-    
-    // Json Set Code
+
+    /**
+     * Json Set Code
+     *
+     * @param $data
+     * @throws \Exception
+     *
+     * @return void
+     */
     public function set($data)
     {
         if(is_array($data) || is_object($data)) {

--- a/lib/net/authorize/api/contract/v1/ANetApiResponseType.php
+++ b/lib/net/authorize/api/contract/v1/ANetApiResponseType.php
@@ -93,7 +93,11 @@ class ANetApiResponseType implements \JsonSerializable
     }
 
 
-    // Json Serialize Code
+    /**
+     * Json Serialize Code
+     * 
+     * @return array|mixed
+     */
     public function jsonSerialize(){
         $values = array_filter((array)get_object_vars($this),
         function ($val){
@@ -126,9 +130,16 @@ class ANetApiResponseType implements \JsonSerializable
         else{
             return array_merge(parent::jsonSerialize(), $values);
         }
-    }
-    
-    // Json Set Code
+    } 
+
+    /**
+     * Json Set Code
+     * 
+     * @param $data
+     * @throws \Exception
+     *
+     * @return void
+     */
     public function set($data)
     {
         if(is_array($data) || is_object($data)) {

--- a/lib/net/authorize/api/contract/v1/ARBCancelSubscriptionRequest.php
+++ b/lib/net/authorize/api/contract/v1/ARBCancelSubscriptionRequest.php
@@ -36,7 +36,11 @@ class ARBCancelSubscriptionRequest extends ANetApiRequestType
     }
 
 
-    // Json Serialize Code
+    /**
+     * Json Serialize Code
+     * 
+     * @return array|mixed
+     */
     public function jsonSerialize(){
         $values = array_filter((array)get_object_vars($this),
         function ($val){

--- a/lib/net/authorize/api/contract/v1/ARBCancelSubscriptionResponse.php
+++ b/lib/net/authorize/api/contract/v1/ARBCancelSubscriptionResponse.php
@@ -8,8 +8,14 @@ namespace net\authorize\api\contract\v1;
 class ARBCancelSubscriptionResponse extends ANetApiResponseType
 {
 
-
-    // Json Set Code
+    /**
+     * Json Set Code
+     *
+     * @param $data
+     * @throws \Exception
+     *
+     * @return void
+     */
     public function set($data)
     {
         if(is_array($data) || is_object($data)) {

--- a/lib/net/authorize/api/contract/v1/ARBCreateSubscriptionRequest.php
+++ b/lib/net/authorize/api/contract/v1/ARBCreateSubscriptionRequest.php
@@ -36,7 +36,11 @@ class ARBCreateSubscriptionRequest extends ANetApiRequestType
     }
 
 
-    // Json Serialize Code
+    /**
+     * Json Serialize Code
+     * 
+     * @return array|mixed
+     */
     public function jsonSerialize(){
         $values = array_filter((array)get_object_vars($this),
         function ($val){

--- a/lib/net/authorize/api/contract/v1/ARBCreateSubscriptionResponse.php
+++ b/lib/net/authorize/api/contract/v1/ARBCreateSubscriptionResponse.php
@@ -62,8 +62,14 @@ class ARBCreateSubscriptionResponse extends ANetApiResponseType
         return $this;
     }
 
-
-    // Json Set Code
+    /**
+     * Json Set Code
+     *
+     * @param $data
+     * @throws \Exception
+     *
+     * @return void
+     */
     public function set($data)
     {
         if(is_array($data) || is_object($data)) {

--- a/lib/net/authorize/api/contract/v1/ARBGetSubscriptionListRequest.php
+++ b/lib/net/authorize/api/contract/v1/ARBGetSubscriptionListRequest.php
@@ -91,7 +91,11 @@ class ARBGetSubscriptionListRequest extends ANetApiRequestType
     }
 
 
-    // Json Serialize Code
+    /**
+     * Json Serialize Code
+     * 
+     * @return array|mixed
+     */
     public function jsonSerialize(){
         $values = array_filter((array)get_object_vars($this),
         function ($val){

--- a/lib/net/authorize/api/contract/v1/ARBGetSubscriptionListResponse.php
+++ b/lib/net/authorize/api/contract/v1/ARBGetSubscriptionListResponse.php
@@ -98,8 +98,14 @@ class ARBGetSubscriptionListResponse extends ANetApiResponseType
         return $this;
     }
 
-
-    // Json Set Code
+    /**
+     * Json Set Code
+     *
+     * @param $data
+     * @throws \Exception
+     *
+     * @return void
+     */
     public function set($data)
     {
         if(is_array($data) || is_object($data)) {

--- a/lib/net/authorize/api/contract/v1/ARBGetSubscriptionListSortingType.php
+++ b/lib/net/authorize/api/contract/v1/ARBGetSubscriptionListSortingType.php
@@ -66,7 +66,11 @@ class ARBGetSubscriptionListSortingType implements \JsonSerializable
     }
 
 
-    // Json Serialize Code
+    /**
+     * Json Serialize Code
+     *
+     * @return array|mixed
+     */
     public function jsonSerialize(){
         $values = array_filter((array)get_object_vars($this),
         function ($val){
@@ -100,8 +104,15 @@ class ARBGetSubscriptionListSortingType implements \JsonSerializable
             return array_merge(parent::jsonSerialize(), $values);
         }
     }
-    
-    // Json Set Code
+
+    /**
+     * Json Set Code
+     *
+     * @param $data
+     * @throws \Exception
+     *
+     * @return void
+     */
     public function set($data)
     {
         if(is_array($data) || is_object($data)) {

--- a/lib/net/authorize/api/contract/v1/ARBGetSubscriptionRequest.php
+++ b/lib/net/authorize/api/contract/v1/ARBGetSubscriptionRequest.php
@@ -63,7 +63,11 @@ class ARBGetSubscriptionRequest extends ANetApiRequestType
     }
 
 
-    // Json Serialize Code
+    /**
+     * Json Serialize Code
+     *
+     * @return array|mixed
+     */
     public function jsonSerialize(){
         $values = array_filter((array)get_object_vars($this),
         function ($val){

--- a/lib/net/authorize/api/contract/v1/ARBGetSubscriptionResponse.php
+++ b/lib/net/authorize/api/contract/v1/ARBGetSubscriptionResponse.php
@@ -35,8 +35,14 @@ class ARBGetSubscriptionResponse extends ANetApiResponseType
         return $this;
     }
 
-
-    // Json Set Code
+    /**
+     * Json Set Code
+     *
+     * @param $data
+     * @throws \Exception
+     *
+     * @return void
+     */
     public function set($data)
     {
         if(is_array($data) || is_object($data)) {

--- a/lib/net/authorize/api/contract/v1/ARBGetSubscriptionStatusRequest.php
+++ b/lib/net/authorize/api/contract/v1/ARBGetSubscriptionStatusRequest.php
@@ -36,7 +36,11 @@ class ARBGetSubscriptionStatusRequest extends ANetApiRequestType
     }
 
 
-    // Json Serialize Code
+    /**
+     * Json Serialize Code
+     * 
+     * @return array|mixed
+     */
     public function jsonSerialize(){
         $values = array_filter((array)get_object_vars($this),
         function ($val){

--- a/lib/net/authorize/api/contract/v1/ARBGetSubscriptionStatusResponse.php
+++ b/lib/net/authorize/api/contract/v1/ARBGetSubscriptionStatusResponse.php
@@ -33,10 +33,16 @@ class ARBGetSubscriptionStatusResponse extends ANetApiResponseType
     {
         $this->status = $status;
         return $this;
-    }
+    } 
 
-
-    // Json Set Code
+    /**
+     * Json Set Code
+     * 
+     * @param $data
+     * @throws \Exception
+     *
+     * @return void
+     */
     public function set($data)
     {
         if(is_array($data) || is_object($data)) {

--- a/lib/net/authorize/api/contract/v1/ARBSubscriptionMaskedType.php
+++ b/lib/net/authorize/api/contract/v1/ARBSubscriptionMaskedType.php
@@ -263,7 +263,11 @@ class ARBSubscriptionMaskedType implements \JsonSerializable
     }
 
 
-    // Json Serialize Code
+    /**
+     * Json Serialize Code
+     * 
+     * @return array|mixed
+     */
     public function jsonSerialize(){
         $values = array_filter((array)get_object_vars($this),
         function ($val){
@@ -296,9 +300,16 @@ class ARBSubscriptionMaskedType implements \JsonSerializable
         else{
             return array_merge(parent::jsonSerialize(), $values);
         }
-    }
-    
-    // Json Set Code
+    } 
+
+    /**
+     * Json Set Code
+     * 
+     * @param $data
+     * @throws \Exception
+     *
+     * @return void
+     */
     public function set($data)
     {
         if(is_array($data) || is_object($data)) {

--- a/lib/net/authorize/api/contract/v1/ARBSubscriptionType.php
+++ b/lib/net/authorize/api/contract/v1/ARBSubscriptionType.php
@@ -282,7 +282,11 @@ class ARBSubscriptionType implements \JsonSerializable
     }
 
 
-    // Json Serialize Code
+    /**
+     * Json Serialize Code
+     *
+     * @return array|mixed
+     */
     public function jsonSerialize(){
         $values = array_filter((array)get_object_vars($this),
         function ($val){
@@ -316,8 +320,15 @@ class ARBSubscriptionType implements \JsonSerializable
             return array_merge(parent::jsonSerialize(), $values);
         }
     }
-    
-    // Json Set Code
+
+    /**
+     * Json Set Code
+     *
+     * @param $data
+     * @throws \Exception
+     *
+     * @return void
+     */
     public function set($data)
     {
         if(is_array($data) || is_object($data)) {

--- a/lib/net/authorize/api/contract/v1/ARBUpdateSubscriptionRequest.php
+++ b/lib/net/authorize/api/contract/v1/ARBUpdateSubscriptionRequest.php
@@ -63,7 +63,11 @@ class ARBUpdateSubscriptionRequest extends ANetApiRequestType
     }
 
 
-    // Json Serialize Code
+    /**
+     * Json Serialize Code
+     *
+     * @return array|mixed
+     */
     public function jsonSerialize(){
         $values = array_filter((array)get_object_vars($this),
         function ($val){

--- a/lib/net/authorize/api/contract/v1/ARBUpdateSubscriptionResponse.php
+++ b/lib/net/authorize/api/contract/v1/ARBUpdateSubscriptionResponse.php
@@ -33,10 +33,16 @@ class ARBUpdateSubscriptionResponse extends ANetApiResponseType
     {
         $this->profile = $profile;
         return $this;
-    }
+    } 
 
-
-    // Json Set Code
+    /**
+     * Json Set Code
+     * 
+     * @param $data
+     * @throws \Exception
+     *
+     * @return void
+     */
     public function set($data)
     {
         if(is_array($data) || is_object($data)) {

--- a/lib/net/authorize/api/contract/v1/ArbTransactionType.php
+++ b/lib/net/authorize/api/contract/v1/ArbTransactionType.php
@@ -147,7 +147,11 @@ class ArbTransactionType implements \JsonSerializable
     }
 
 
-    // Json Serialize Code
+    /**
+     * Json Serialize Code
+     * 
+     * @return array|mixed
+     */
     public function jsonSerialize(){
         $values = array_filter((array)get_object_vars($this),
         function ($val){
@@ -180,9 +184,16 @@ class ArbTransactionType implements \JsonSerializable
         else{
             return array_merge(parent::jsonSerialize(), $values);
         }
-    }
-    
-    // Json Set Code
+    } 
+
+    /**
+     * Json Set Code
+     * 
+     * @param $data
+     * @throws \Exception
+     *
+     * @return void
+     */
     public function set($data)
     {
         if(is_array($data) || is_object($data)) {

--- a/lib/net/authorize/api/contract/v1/ArrayOfSettingType.php
+++ b/lib/net/authorize/api/contract/v1/ArrayOfSettingType.php
@@ -73,7 +73,11 @@ class ArrayOfSettingType implements \JsonSerializable
     }
 
 
-    // Json Serialize Code
+    /**
+     * Json Serialize Code
+     * 
+     * @return array|mixed
+     */
     public function jsonSerialize(){
         $values = array_filter((array)get_object_vars($this),
         function ($val){
@@ -106,9 +110,16 @@ class ArrayOfSettingType implements \JsonSerializable
         else{
             return array_merge(parent::jsonSerialize(), $values);
         }
-    }
-    
-    // Json Set Code
+    } 
+
+    /**
+     * Json Set Code
+     * 
+     * @param $data
+     * @throws \Exception
+     *
+     * @return void
+     */
     public function set($data)
     {
         if(is_array($data) || is_object($data)) {

--- a/lib/net/authorize/api/contract/v1/AuDeleteType.php
+++ b/lib/net/authorize/api/contract/v1/AuDeleteType.php
@@ -39,7 +39,11 @@ class AuDeleteType extends AuDetailsType implements \JsonSerializable
     }
 
 
-    // Json Serialize Code
+    /**
+     * Json Serialize Code
+     * 
+     * @return array|mixed
+     */
     public function jsonSerialize(){
         $values = array_filter((array)get_object_vars($this),
         function ($val){
@@ -72,9 +76,16 @@ class AuDeleteType extends AuDetailsType implements \JsonSerializable
         else{
             return array_merge(parent::jsonSerialize(), $values);
         }
-    }
-    
-    // Json Set Code
+    } 
+
+    /**
+     * Json Set Code
+     * 
+     * @param $data
+     * @throws \Exception
+     *
+     * @return void
+     */
     public function set($data)
     {
         if(is_array($data) || is_object($data)) {

--- a/lib/net/authorize/api/contract/v1/AuDetailsType.php
+++ b/lib/net/authorize/api/contract/v1/AuDetailsType.php
@@ -201,7 +201,11 @@ class AuDetailsType implements \JsonSerializable
     }
 
 
-    // Json Serialize Code
+    /**
+     * Json Serialize Code
+     *
+     * @return array|mixed
+     */
     public function jsonSerialize(){
         $values = array_filter((array)get_object_vars($this),
         function ($val){
@@ -235,8 +239,15 @@ class AuDetailsType implements \JsonSerializable
             return array_merge(parent::jsonSerialize(), $values);
         }
     }
-    
-    // Json Set Code
+
+    /**
+     * Json Set Code
+     *
+     * @param $data
+     * @throws \Exception
+     *
+     * @return void
+     */
     public function set($data)
     {
         if(is_array($data) || is_object($data)) {

--- a/lib/net/authorize/api/contract/v1/AuResponseType.php
+++ b/lib/net/authorize/api/contract/v1/AuResponseType.php
@@ -93,7 +93,11 @@ class AuResponseType implements \JsonSerializable
     }
 
 
-    // Json Serialize Code
+    /**
+     * Json Serialize Code
+     *
+     * @return array|mixed
+     */
     public function jsonSerialize(){
         $values = array_filter((array)get_object_vars($this),
         function ($val){
@@ -127,8 +131,15 @@ class AuResponseType implements \JsonSerializable
             return array_merge(parent::jsonSerialize(), $values);
         }
     }
-    
-    // Json Set Code
+
+    /**
+     * Json Set Code
+     *
+     * @param $data
+     * @throws \Exception
+     *
+     * @return void
+     */
     public function set($data)
     {
         if(is_array($data) || is_object($data)) {

--- a/lib/net/authorize/api/contract/v1/AuUpdateType.php
+++ b/lib/net/authorize/api/contract/v1/AuUpdateType.php
@@ -66,7 +66,11 @@ class AuUpdateType extends AuDetailsType implements \JsonSerializable
     }
 
 
-    // Json Serialize Code
+    /**
+     * Json Serialize Code
+     * 
+     * @return array|mixed
+     */
     public function jsonSerialize(){
         $values = array_filter((array)get_object_vars($this),
         function ($val){
@@ -99,9 +103,16 @@ class AuUpdateType extends AuDetailsType implements \JsonSerializable
         else{
             return array_merge(parent::jsonSerialize(), $values);
         }
-    }
-    
-    // Json Set Code
+    } 
+
+    /**
+     * Json Set Code
+     * 
+     * @param $data
+     * @throws \Exception
+     *
+     * @return void
+     */
     public function set($data)
     {
         if(is_array($data) || is_object($data)) {

--- a/lib/net/authorize/api/contract/v1/AuthenticateTestRequest.php
+++ b/lib/net/authorize/api/contract/v1/AuthenticateTestRequest.php
@@ -9,7 +9,11 @@ class AuthenticateTestRequest extends ANetApiRequestType
 {
 
 
-    // Json Serialize Code
+    /**
+     * Json Serialize Code
+     *
+     * @return array|mixed
+     */
     public function jsonSerialize(){
         $values = array_filter((array)get_object_vars($this),
         function ($val){

--- a/lib/net/authorize/api/contract/v1/AuthenticateTestResponse.php
+++ b/lib/net/authorize/api/contract/v1/AuthenticateTestResponse.php
@@ -8,8 +8,14 @@ namespace net\authorize\api\contract\v1;
 class AuthenticateTestResponse extends ANetApiResponseType
 {
 
-
-    // Json Set Code
+    /**
+     * Json Set Code
+     *
+     * @param $data
+     * @throws \Exception
+     *
+     * @return void
+     */
     public function set($data)
     {
         if(is_array($data) || is_object($data)) {

--- a/lib/net/authorize/api/contract/v1/BankAccountMaskedType.php
+++ b/lib/net/authorize/api/contract/v1/BankAccountMaskedType.php
@@ -174,7 +174,11 @@ class BankAccountMaskedType implements \JsonSerializable
     }
 
 
-    // Json Serialize Code
+    /**
+     * Json Serialize Code
+     *
+     * @return array|mixed
+     */
     public function jsonSerialize(){
         $values = array_filter((array)get_object_vars($this),
         function ($val){
@@ -208,8 +212,15 @@ class BankAccountMaskedType implements \JsonSerializable
             return array_merge(parent::jsonSerialize(), $values);
         }
     }
-    
-    // Json Set Code
+
+    /**
+     * Json Set Code
+     *
+     * @param $data
+     * @throws \Exception
+     *
+     * @return void
+     */
     public function set($data)
     {
         if(is_array($data) || is_object($data)) {

--- a/lib/net/authorize/api/contract/v1/BankAccountType.php
+++ b/lib/net/authorize/api/contract/v1/BankAccountType.php
@@ -201,7 +201,11 @@ class BankAccountType implements \JsonSerializable
     }
 
 
-    // Json Serialize Code
+    /**
+     * Json Serialize Code
+     * 
+     * @return array|mixed
+     */
     public function jsonSerialize(){
         $values = array_filter((array)get_object_vars($this),
         function ($val){
@@ -234,9 +238,16 @@ class BankAccountType implements \JsonSerializable
         else{
             return array_merge(parent::jsonSerialize(), $values);
         }
-    }
-    
-    // Json Set Code
+    } 
+
+    /**
+     * Json Set Code
+     * 
+     * @param $data
+     * @throws \Exception
+     *
+     * @return void
+     */
     public function set($data)
     {
         if(is_array($data) || is_object($data)) {

--- a/lib/net/authorize/api/contract/v1/BatchDetailsType.php
+++ b/lib/net/authorize/api/contract/v1/BatchDetailsType.php
@@ -262,7 +262,11 @@ class BatchDetailsType implements \JsonSerializable
     }
 
 
-    // Json Serialize Code
+    /**
+     * Json Serialize Code
+     *
+     * @return array|mixed
+     */
     public function jsonSerialize(){
         $values = array_filter((array)get_object_vars($this),
         function ($val){
@@ -296,8 +300,15 @@ class BatchDetailsType implements \JsonSerializable
             return array_merge(parent::jsonSerialize(), $values);
         }
     }
-    
-    // Json Set Code
+
+    /**
+     * Json Set Code
+     *
+     * @param $data
+     * @throws \Exception
+     *
+     * @return void
+     */
     public function set($data)
     {
         if(is_array($data) || is_object($data)) {

--- a/lib/net/authorize/api/contract/v1/BatchStatisticType.php
+++ b/lib/net/authorize/api/contract/v1/BatchStatisticType.php
@@ -579,7 +579,11 @@ class BatchStatisticType implements \JsonSerializable
     }
 
 
-    // Json Serialize Code
+    /**
+     * Json Serialize Code
+     * 
+     * @return array|mixed
+     */
     public function jsonSerialize(){
         $values = array_filter((array)get_object_vars($this),
         function ($val){
@@ -612,9 +616,16 @@ class BatchStatisticType implements \JsonSerializable
         else{
             return array_merge(parent::jsonSerialize(), $values);
         }
-    }
-    
-    // Json Set Code
+    } 
+
+    /**
+     * Json Set Code
+     * 
+     * @param $data
+     * @throws \Exception
+     *
+     * @return void
+     */
     public function set($data)
     {
         if(is_array($data) || is_object($data)) {

--- a/lib/net/authorize/api/contract/v1/CardArtType.php
+++ b/lib/net/authorize/api/contract/v1/CardArtType.php
@@ -147,7 +147,11 @@ class CardArtType implements \JsonSerializable
     }
 
 
-    // Json Serialize Code
+    /**
+     * Json Serialize Code
+     *
+     * @return array|mixed
+     */
     public function jsonSerialize(){
         $values = array_filter((array)get_object_vars($this),
         function ($val){
@@ -181,8 +185,15 @@ class CardArtType implements \JsonSerializable
             return array_merge(parent::jsonSerialize(), $values);
         }
     }
-    
-    // Json Set Code
+
+    /**
+     * Json Set Code
+     *
+     * @param $data
+     * @throws \Exception
+     *
+     * @return void
+     */
     public function set($data)
     {
         if(is_array($data) || is_object($data)) {

--- a/lib/net/authorize/api/contract/v1/CcAuthenticationType.php
+++ b/lib/net/authorize/api/contract/v1/CcAuthenticationType.php
@@ -66,7 +66,11 @@ class CcAuthenticationType implements \JsonSerializable
     }
 
 
-    // Json Serialize Code
+    /**
+     * Json Serialize Code
+     * 
+     * @return array|mixed
+     */
     public function jsonSerialize(){
         $values = array_filter((array)get_object_vars($this),
         function ($val){
@@ -99,9 +103,16 @@ class CcAuthenticationType implements \JsonSerializable
         else{
             return array_merge(parent::jsonSerialize(), $values);
         }
-    }
-    
-    // Json Set Code
+    } 
+
+    /**
+     * Json Set Code
+     * 
+     * @param $data
+     * @throws \Exception
+     *
+     * @return void
+     */
     public function set($data)
     {
         if(is_array($data) || is_object($data)) {

--- a/lib/net/authorize/api/contract/v1/CreateCustomerPaymentProfileRequest.php
+++ b/lib/net/authorize/api/contract/v1/CreateCustomerPaymentProfileRequest.php
@@ -91,7 +91,11 @@ class CreateCustomerPaymentProfileRequest extends ANetApiRequestType
     }
 
 
-    // Json Serialize Code
+    /**
+     * Json Serialize Code
+     *
+     * @return array|mixed
+     */
     public function jsonSerialize(){
         $values = array_filter((array)get_object_vars($this),
         function ($val){

--- a/lib/net/authorize/api/contract/v1/CreateCustomerPaymentProfileResponse.php
+++ b/lib/net/authorize/api/contract/v1/CreateCustomerPaymentProfileResponse.php
@@ -87,10 +87,16 @@ class CreateCustomerPaymentProfileResponse extends ANetApiResponseType
     {
         $this->validationDirectResponse = $validationDirectResponse;
         return $this;
-    }
+    } 
 
-
-    // Json Set Code
+    /**
+     * Json Set Code
+     * 
+     * @param $data
+     * @throws \Exception
+     *
+     * @return void
+     */
     public function set($data)
     {
         if(is_array($data) || is_object($data)) {

--- a/lib/net/authorize/api/contract/v1/CreateCustomerProfileFromTransactionRequest.php
+++ b/lib/net/authorize/api/contract/v1/CreateCustomerProfileFromTransactionRequest.php
@@ -171,7 +171,11 @@ class CreateCustomerProfileFromTransactionRequest extends ANetApiRequestType
     }
 
 
-    // Json Serialize Code
+    /**
+     * Json Serialize Code
+     * 
+     * @return array|mixed
+     */
     public function jsonSerialize(){
         $values = array_filter((array)get_object_vars($this),
         function ($val){

--- a/lib/net/authorize/api/contract/v1/CreateCustomerProfileRequest.php
+++ b/lib/net/authorize/api/contract/v1/CreateCustomerProfileRequest.php
@@ -63,7 +63,11 @@ class CreateCustomerProfileRequest extends ANetApiRequestType
     }
 
 
-    // Json Serialize Code
+    /**
+     * Json Serialize Code
+     *
+     * @return array|mixed
+     */
     public function jsonSerialize(){
         $values = array_filter((array)get_object_vars($this),
         function ($val){

--- a/lib/net/authorize/api/contract/v1/CreateCustomerProfileResponse.php
+++ b/lib/net/authorize/api/contract/v1/CreateCustomerProfileResponse.php
@@ -216,10 +216,16 @@ class CreateCustomerProfileResponse extends ANetApiResponseType
     {
         $this->validationDirectResponseList = $validationDirectResponseList;
         return $this;
-    }
+    } 
 
-
-    // Json Set Code
+    /**
+     * Json Set Code
+     * 
+     * @param $data
+     * @throws \Exception
+     *
+     * @return void
+     */
     public function set($data)
     {
         if(is_array($data) || is_object($data)) {

--- a/lib/net/authorize/api/contract/v1/CreateCustomerProfileTransactionRequest.php
+++ b/lib/net/authorize/api/contract/v1/CreateCustomerProfileTransactionRequest.php
@@ -63,7 +63,11 @@ class CreateCustomerProfileTransactionRequest extends ANetApiRequestType
     }
 
 
-    // Json Serialize Code
+    /**
+     * Json Serialize Code
+     * 
+     * @return array|mixed
+     */
     public function jsonSerialize(){
         $values = array_filter((array)get_object_vars($this),
         function ($val){

--- a/lib/net/authorize/api/contract/v1/CreateCustomerProfileTransactionResponse.php
+++ b/lib/net/authorize/api/contract/v1/CreateCustomerProfileTransactionResponse.php
@@ -62,10 +62,16 @@ class CreateCustomerProfileTransactionResponse extends ANetApiResponseType
     {
         $this->directResponse = $directResponse;
         return $this;
-    }
+    } 
 
-
-    // Json Set Code
+    /**
+     * Json Set Code
+     * 
+     * @param $data
+     * @throws \Exception
+     *
+     * @return void
+     */
     public function set($data)
     {
         if(is_array($data) || is_object($data)) {

--- a/lib/net/authorize/api/contract/v1/CreateCustomerShippingAddressRequest.php
+++ b/lib/net/authorize/api/contract/v1/CreateCustomerShippingAddressRequest.php
@@ -90,7 +90,11 @@ class CreateCustomerShippingAddressRequest extends ANetApiRequestType
     }
 
 
-    // Json Serialize Code
+    /**
+     * Json Serialize Code
+     * 
+     * @return array|mixed
+     */
     public function jsonSerialize(){
         $values = array_filter((array)get_object_vars($this),
         function ($val){

--- a/lib/net/authorize/api/contract/v1/CreateCustomerShippingAddressResponse.php
+++ b/lib/net/authorize/api/contract/v1/CreateCustomerShippingAddressResponse.php
@@ -62,8 +62,14 @@ class CreateCustomerShippingAddressResponse extends ANetApiResponseType
         return $this;
     }
 
-
-    // Json Set Code
+    /**
+     * Json Set Code
+     *
+     * @param $data
+     * @throws \Exception
+     *
+     * @return void
+     */
     public function set($data)
     {
         if(is_array($data) || is_object($data)) {

--- a/lib/net/authorize/api/contract/v1/CreateProfileResponseType.php
+++ b/lib/net/authorize/api/contract/v1/CreateProfileResponseType.php
@@ -188,7 +188,11 @@ class CreateProfileResponseType implements \JsonSerializable
     }
 
 
-    // Json Serialize Code
+    /**
+     * Json Serialize Code
+     *
+     * @return array|mixed
+     */
     public function jsonSerialize(){
         $values = array_filter((array)get_object_vars($this),
         function ($val){
@@ -222,8 +226,15 @@ class CreateProfileResponseType implements \JsonSerializable
             return array_merge(parent::jsonSerialize(), $values);
         }
     }
-    
-    // Json Set Code
+
+    /**
+     * Json Set Code
+     *
+     * @param $data
+     * @throws \Exception
+     *
+     * @return void
+     */
     public function set($data)
     {
         if(is_array($data) || is_object($data)) {

--- a/lib/net/authorize/api/contract/v1/CreateTransactionRequest.php
+++ b/lib/net/authorize/api/contract/v1/CreateTransactionRequest.php
@@ -37,7 +37,11 @@ class CreateTransactionRequest extends ANetApiRequestType
     }
 
 
-    // Json Serialize Code
+    /**
+     * Json Serialize Code
+     *
+     * @return array|mixed
+     */
     public function jsonSerialize(){
         $values = array_filter((array)get_object_vars($this),
         function ($val){

--- a/lib/net/authorize/api/contract/v1/CreateTransactionResponse.php
+++ b/lib/net/authorize/api/contract/v1/CreateTransactionResponse.php
@@ -65,8 +65,14 @@ class CreateTransactionResponse extends ANetApiResponseType
         return $this;
     }
 
-
-    // Json Set Code
+    /**
+     * Json Set Code
+     *
+     * @param $data
+     * @throws \Exception
+     *
+     * @return void
+     */
     public function set($data)
     {
         if(is_array($data) || is_object($data)) {

--- a/lib/net/authorize/api/contract/v1/CreditCardMaskedType.php
+++ b/lib/net/authorize/api/contract/v1/CreditCardMaskedType.php
@@ -174,7 +174,11 @@ class CreditCardMaskedType implements \JsonSerializable
     }
 
 
-    // Json Serialize Code
+    /**
+     * Json Serialize Code
+     *
+     * @return array|mixed
+     */
     public function jsonSerialize(){
         $values = array_filter((array)get_object_vars($this),
         function ($val){
@@ -208,8 +212,15 @@ class CreditCardMaskedType implements \JsonSerializable
             return array_merge(parent::jsonSerialize(), $values);
         }
     }
-    
-    // Json Set Code
+
+    /**
+     * Json Set Code
+     *
+     * @param $data
+     * @throws \Exception
+     *
+     * @return void
+     */
     public function set($data)
     {
         if(is_array($data) || is_object($data)) {

--- a/lib/net/authorize/api/contract/v1/CreditCardSimpleType.php
+++ b/lib/net/authorize/api/contract/v1/CreditCardSimpleType.php
@@ -66,7 +66,11 @@ class CreditCardSimpleType implements \JsonSerializable
     }
 
 
-    // Json Serialize Code
+    /**
+     * Json Serialize Code
+     * 
+     * @return array|mixed
+     */
     public function jsonSerialize(){
         $values = array_filter((array)get_object_vars($this),
         function ($val){
@@ -99,9 +103,16 @@ class CreditCardSimpleType implements \JsonSerializable
         else{
             return array_merge(parent::jsonSerialize(), $values);
         }
-    }
-    
-    // Json Set Code
+    } 
+
+    /**
+     * Json Set Code
+     * 
+     * @param $data
+     * @throws \Exception
+     *
+     * @return void
+     */
     public function set($data)
     {
         if(is_array($data) || is_object($data)) {

--- a/lib/net/authorize/api/contract/v1/CreditCardTrackType.php
+++ b/lib/net/authorize/api/contract/v1/CreditCardTrackType.php
@@ -66,7 +66,11 @@ class CreditCardTrackType implements \JsonSerializable
     }
 
 
-    // Json Serialize Code
+    /**
+     * Json Serialize Code
+     *
+     * @return array|mixed
+     */
     public function jsonSerialize(){
         $values = array_filter((array)get_object_vars($this),
         function ($val){
@@ -100,8 +104,15 @@ class CreditCardTrackType implements \JsonSerializable
             return array_merge(parent::jsonSerialize(), $values);
         }
     }
-    
-    // Json Set Code
+
+    /**
+     * Json Set Code
+     *
+     * @param $data
+     * @throws \Exception
+     *
+     * @return void
+     */
     public function set($data)
     {
         if(is_array($data) || is_object($data)) {

--- a/lib/net/authorize/api/contract/v1/CreditCardType.php
+++ b/lib/net/authorize/api/contract/v1/CreditCardType.php
@@ -174,7 +174,11 @@ class CreditCardType extends CreditCardSimpleType implements \JsonSerializable
     }
 
 
-    // Json Serialize Code
+    /**
+     * Json Serialize Code
+     *
+     * @return array|mixed
+     */
     public function jsonSerialize(){
         $values = array_filter((array)get_object_vars($this),
         function ($val){
@@ -208,8 +212,15 @@ class CreditCardType extends CreditCardSimpleType implements \JsonSerializable
             return array_merge(parent::jsonSerialize(), $values);
         }
     }
-    
-    // Json Set Code
+
+    /**
+     * Json Set Code
+     *
+     * @param $data
+     * @throws \Exception
+     *
+     * @return void
+     */
     public function set($data)
     {
         if(is_array($data) || is_object($data)) {

--- a/lib/net/authorize/api/contract/v1/CustomerAddressExType.php
+++ b/lib/net/authorize/api/contract/v1/CustomerAddressExType.php
@@ -39,7 +39,11 @@ class CustomerAddressExType extends CustomerAddressType implements \JsonSerializ
     }
 
 
-    // Json Serialize Code
+    /**
+     * Json Serialize Code
+     * 
+     * @return array|mixed
+     */
     public function jsonSerialize(){
         $values = array_filter((array)get_object_vars($this),
         function ($val){
@@ -72,9 +76,16 @@ class CustomerAddressExType extends CustomerAddressType implements \JsonSerializ
         else{
             return array_merge(parent::jsonSerialize(), $values);
         }
-    }
-    
-    // Json Set Code
+    } 
+
+    /**
+     * Json Set Code
+     * 
+     * @param $data
+     * @throws \Exception
+     *
+     * @return void
+     */
     public function set($data)
     {
         if(is_array($data) || is_object($data)) {

--- a/lib/net/authorize/api/contract/v1/CustomerAddressType.php
+++ b/lib/net/authorize/api/contract/v1/CustomerAddressType.php
@@ -93,7 +93,11 @@ class CustomerAddressType extends NameAndAddressType implements \JsonSerializabl
     }
 
 
-    // Json Serialize Code
+    /**
+     * Json Serialize Code
+     * 
+     * @return array|mixed
+     */
     public function jsonSerialize(){
         $values = array_filter((array)get_object_vars($this),
         function ($val){
@@ -126,9 +130,16 @@ class CustomerAddressType extends NameAndAddressType implements \JsonSerializabl
         else{
             return array_merge(parent::jsonSerialize(), $values);
         }
-    }
-    
-    // Json Set Code
+    } 
+
+    /**
+     * Json Set Code
+     * 
+     * @param $data
+     * @throws \Exception
+     *
+     * @return void
+     */
     public function set($data)
     {
         if(is_array($data) || is_object($data)) {

--- a/lib/net/authorize/api/contract/v1/CustomerDataType.php
+++ b/lib/net/authorize/api/contract/v1/CustomerDataType.php
@@ -147,7 +147,11 @@ class CustomerDataType implements \JsonSerializable
     }
 
 
-    // Json Serialize Code
+    /**
+     * Json Serialize Code
+     *
+     * @return array|mixed
+     */
     public function jsonSerialize(){
         $values = array_filter((array)get_object_vars($this),
         function ($val){
@@ -181,8 +185,15 @@ class CustomerDataType implements \JsonSerializable
             return array_merge(parent::jsonSerialize(), $values);
         }
     }
-    
-    // Json Set Code
+
+    /**
+     * Json Set Code
+     *
+     * @param $data
+     * @throws \Exception
+     *
+     * @return void
+     */
     public function set($data)
     {
         if(is_array($data) || is_object($data)) {

--- a/lib/net/authorize/api/contract/v1/CustomerPaymentProfileBaseType.php
+++ b/lib/net/authorize/api/contract/v1/CustomerPaymentProfileBaseType.php
@@ -66,7 +66,11 @@ class CustomerPaymentProfileBaseType implements \JsonSerializable
     }
 
 
-    // Json Serialize Code
+    /**
+     * Json Serialize Code
+     *
+     * @return array|mixed
+     */
     public function jsonSerialize(){
         $values = array_filter((array)get_object_vars($this),
         function ($val){
@@ -100,8 +104,15 @@ class CustomerPaymentProfileBaseType implements \JsonSerializable
             return array_merge(parent::jsonSerialize(), $values);
         }
     }
-    
-    // Json Set Code
+
+    /**
+     * Json Set Code
+     *
+     * @param $data
+     * @throws \Exception
+     *
+     * @return void
+     */
     public function set($data)
     {
         if(is_array($data) || is_object($data)) {

--- a/lib/net/authorize/api/contract/v1/CustomerPaymentProfileExType.php
+++ b/lib/net/authorize/api/contract/v1/CustomerPaymentProfileExType.php
@@ -39,7 +39,11 @@ class CustomerPaymentProfileExType extends CustomerPaymentProfileType implements
     }
 
 
-    // Json Serialize Code
+    /**
+     * Json Serialize Code
+     * 
+     * @return array|mixed
+     */
     public function jsonSerialize(){
         $values = array_filter((array)get_object_vars($this),
         function ($val){
@@ -72,9 +76,16 @@ class CustomerPaymentProfileExType extends CustomerPaymentProfileType implements
         else{
             return array_merge(parent::jsonSerialize(), $values);
         }
-    }
-    
-    // Json Set Code
+    } 
+
+    /**
+     * Json Set Code
+     * 
+     * @param $data
+     * @throws \Exception
+     *
+     * @return void
+     */
     public function set($data)
     {
         if(is_array($data) || is_object($data)) {

--- a/lib/net/authorize/api/contract/v1/CustomerPaymentProfileListItemType.php
+++ b/lib/net/authorize/api/contract/v1/CustomerPaymentProfileListItemType.php
@@ -147,7 +147,11 @@ class CustomerPaymentProfileListItemType implements \JsonSerializable
     }
 
 
-    // Json Serialize Code
+    /**
+     * Json Serialize Code
+     * 
+     * @return array|mixed
+     */
     public function jsonSerialize(){
         $values = array_filter((array)get_object_vars($this),
         function ($val){
@@ -180,9 +184,16 @@ class CustomerPaymentProfileListItemType implements \JsonSerializable
         else{
             return array_merge(parent::jsonSerialize(), $values);
         }
-    }
-    
-    // Json Set Code
+    } 
+
+    /**
+     * Json Set Code
+     * 
+     * @param $data
+     * @throws \Exception
+     *
+     * @return void
+     */
     public function set($data)
     {
         if(is_array($data) || is_object($data)) {

--- a/lib/net/authorize/api/contract/v1/CustomerPaymentProfileMaskedType.php
+++ b/lib/net/authorize/api/contract/v1/CustomerPaymentProfileMaskedType.php
@@ -236,7 +236,11 @@ class CustomerPaymentProfileMaskedType extends CustomerPaymentProfileBaseType im
     }
 
 
-    // Json Serialize Code
+    /**
+     * Json Serialize Code
+     *
+     * @return array|mixed
+     */
     public function jsonSerialize(){
         $values = array_filter((array)get_object_vars($this),
         function ($val){
@@ -270,8 +274,15 @@ class CustomerPaymentProfileMaskedType extends CustomerPaymentProfileBaseType im
             return array_merge(parent::jsonSerialize(), $values);
         }
     }
-    
-    // Json Set Code
+
+    /**
+     * Json Set Code
+     *
+     * @param $data
+     * @throws \Exception
+     *
+     * @return void
+     */
     public function set($data)
     {
         if(is_array($data) || is_object($data)) {

--- a/lib/net/authorize/api/contract/v1/CustomerPaymentProfileSortingType.php
+++ b/lib/net/authorize/api/contract/v1/CustomerPaymentProfileSortingType.php
@@ -66,7 +66,11 @@ class CustomerPaymentProfileSortingType implements \JsonSerializable
     }
 
 
-    // Json Serialize Code
+    /**
+     * Json Serialize Code
+     * 
+     * @return array|mixed
+     */
     public function jsonSerialize(){
         $values = array_filter((array)get_object_vars($this),
         function ($val){
@@ -99,9 +103,16 @@ class CustomerPaymentProfileSortingType implements \JsonSerializable
         else{
             return array_merge(parent::jsonSerialize(), $values);
         }
-    }
-    
-    // Json Set Code
+    } 
+
+    /**
+     * Json Set Code
+     * 
+     * @param $data
+     * @throws \Exception
+     *
+     * @return void
+     */
     public function set($data)
     {
         if(is_array($data) || is_object($data)) {

--- a/lib/net/authorize/api/contract/v1/CustomerPaymentProfileType.php
+++ b/lib/net/authorize/api/contract/v1/CustomerPaymentProfileType.php
@@ -120,7 +120,11 @@ class CustomerPaymentProfileType extends CustomerPaymentProfileBaseType implemen
     }
 
 
-    // Json Serialize Code
+    /**
+     * Json Serialize Code
+     * 
+     * @return array|mixed
+     */
     public function jsonSerialize(){
         $values = array_filter((array)get_object_vars($this),
         function ($val){
@@ -153,9 +157,16 @@ class CustomerPaymentProfileType extends CustomerPaymentProfileBaseType implemen
         else{
             return array_merge(parent::jsonSerialize(), $values);
         }
-    }
-    
-    // Json Set Code
+    } 
+
+    /**
+     * Json Set Code
+     * 
+     * @param $data
+     * @throws \Exception
+     *
+     * @return void
+     */
     public function set($data)
     {
         if(is_array($data) || is_object($data)) {

--- a/lib/net/authorize/api/contract/v1/CustomerProfileBaseType.php
+++ b/lib/net/authorize/api/contract/v1/CustomerProfileBaseType.php
@@ -93,7 +93,11 @@ class CustomerProfileBaseType implements \JsonSerializable
     }
 
 
-    // Json Serialize Code
+    /**
+     * Json Serialize Code
+     * 
+     * @return array|mixed
+     */
     public function jsonSerialize(){
         $values = array_filter((array)get_object_vars($this),
         function ($val){
@@ -126,9 +130,16 @@ class CustomerProfileBaseType implements \JsonSerializable
         else{
             return array_merge(parent::jsonSerialize(), $values);
         }
-    }
-    
-    // Json Set Code
+    } 
+
+    /**
+     * Json Set Code
+     * 
+     * @param $data
+     * @throws \Exception
+     *
+     * @return void
+     */
     public function set($data)
     {
         if(is_array($data) || is_object($data)) {

--- a/lib/net/authorize/api/contract/v1/CustomerProfileExType.php
+++ b/lib/net/authorize/api/contract/v1/CustomerProfileExType.php
@@ -39,7 +39,11 @@ class CustomerProfileExType extends CustomerProfileBaseType implements \JsonSeri
     }
 
 
-    // Json Serialize Code
+    /**
+     * Json Serialize Code
+     *
+     * @return array|mixed
+     */
     public function jsonSerialize(){
         $values = array_filter((array)get_object_vars($this),
         function ($val){
@@ -73,8 +77,15 @@ class CustomerProfileExType extends CustomerProfileBaseType implements \JsonSeri
             return array_merge(parent::jsonSerialize(), $values);
         }
     }
-    
-    // Json Set Code
+
+    /**
+     * Json Set Code
+     *
+     * @param $data
+     * @throws \Exception
+     *
+     * @return void
+     */
     public function set($data)
     {
         if(is_array($data) || is_object($data)) {

--- a/lib/net/authorize/api/contract/v1/CustomerProfileIdType.php
+++ b/lib/net/authorize/api/contract/v1/CustomerProfileIdType.php
@@ -93,7 +93,11 @@ class CustomerProfileIdType implements \JsonSerializable
     }
 
 
-    // Json Serialize Code
+    /**
+     * Json Serialize Code
+     *
+     * @return array|mixed
+     */
     public function jsonSerialize(){
         $values = array_filter((array)get_object_vars($this),
         function ($val){
@@ -127,8 +131,15 @@ class CustomerProfileIdType implements \JsonSerializable
             return array_merge(parent::jsonSerialize(), $values);
         }
     }
-    
-    // Json Set Code
+
+    /**
+     * Json Set Code
+     *
+     * @param $data
+     * @throws \Exception
+     *
+     * @return void
+     */
     public function set($data)
     {
         if(is_array($data) || is_object($data)) {

--- a/lib/net/authorize/api/contract/v1/CustomerProfileInfoExType.php
+++ b/lib/net/authorize/api/contract/v1/CustomerProfileInfoExType.php
@@ -39,7 +39,11 @@ class CustomerProfileInfoExType extends CustomerProfileExType implements \JsonSe
     }
 
 
-    // Json Serialize Code
+    /**
+     * Json Serialize Code
+     * 
+     * @return array|mixed
+     */
     public function jsonSerialize(){
         $values = array_filter((array)get_object_vars($this),
         function ($val){
@@ -72,9 +76,16 @@ class CustomerProfileInfoExType extends CustomerProfileExType implements \JsonSe
         else{
             return array_merge(parent::jsonSerialize(), $values);
         }
-    }
-    
-    // Json Set Code
+    } 
+
+    /**
+     * Json Set Code
+     * 
+     * @param $data
+     * @throws \Exception
+     *
+     * @return void
+     */
     public function set($data)
     {
         if(is_array($data) || is_object($data)) {

--- a/lib/net/authorize/api/contract/v1/CustomerProfileMaskedType.php
+++ b/lib/net/authorize/api/contract/v1/CustomerProfileMaskedType.php
@@ -164,7 +164,11 @@ class CustomerProfileMaskedType extends CustomerProfileExType implements \JsonSe
     }
 
 
-    // Json Serialize Code
+    /**
+     * Json Serialize Code
+     * 
+     * @return array|mixed
+     */
     public function jsonSerialize(){
         $values = array_filter((array)get_object_vars($this),
         function ($val){
@@ -197,9 +201,16 @@ class CustomerProfileMaskedType extends CustomerProfileExType implements \JsonSe
         else{
             return array_merge(parent::jsonSerialize(), $values);
         }
-    }
-    
-    // Json Set Code
+    } 
+
+    /**
+     * Json Set Code
+     * 
+     * @param $data
+     * @throws \Exception
+     *
+     * @return void
+     */
     public function set($data)
     {
         if(is_array($data) || is_object($data)) {

--- a/lib/net/authorize/api/contract/v1/CustomerProfilePaymentType.php
+++ b/lib/net/authorize/api/contract/v1/CustomerProfilePaymentType.php
@@ -120,7 +120,11 @@ class CustomerProfilePaymentType implements \JsonSerializable
     }
 
 
-    // Json Serialize Code
+    /**
+     * Json Serialize Code
+     * 
+     * @return array|mixed
+     */
     public function jsonSerialize(){
         $values = array_filter((array)get_object_vars($this),
         function ($val){
@@ -153,9 +157,16 @@ class CustomerProfilePaymentType implements \JsonSerializable
         else{
             return array_merge(parent::jsonSerialize(), $values);
         }
-    }
-    
-    // Json Set Code
+    } 
+
+    /**
+     * Json Set Code
+     * 
+     * @param $data
+     * @throws \Exception
+     *
+     * @return void
+     */
     public function set($data)
     {
         if(is_array($data) || is_object($data)) {

--- a/lib/net/authorize/api/contract/v1/CustomerProfileSummaryType.php
+++ b/lib/net/authorize/api/contract/v1/CustomerProfileSummaryType.php
@@ -147,7 +147,11 @@ class CustomerProfileSummaryType implements \JsonSerializable
     }
 
 
-    // Json Serialize Code
+    /**
+     * Json Serialize Code
+     *
+     * @return array|mixed
+     */
     public function jsonSerialize(){
         $values = array_filter((array)get_object_vars($this),
         function ($val){
@@ -180,9 +184,16 @@ class CustomerProfileSummaryType implements \JsonSerializable
         else{
             return array_merge(parent::jsonSerialize(), $values);
         }
-    }
-    
-    // Json Set Code
+    } 
+
+    /**
+     * Json Set Code
+     * 
+     * @param $data
+     * @throws \Exception
+     *
+     * @return void
+     */
     public function set($data)
     {
         if(is_array($data) || is_object($data)) {

--- a/lib/net/authorize/api/contract/v1/CustomerProfileType.php
+++ b/lib/net/authorize/api/contract/v1/CustomerProfileType.php
@@ -164,7 +164,11 @@ class CustomerProfileType extends CustomerProfileBaseType implements \JsonSerial
     }
 
 
-    // Json Serialize Code
+    /**
+     * Json Serialize Code
+     * 
+     * @return array|mixed
+     */
     public function jsonSerialize(){
         $values = array_filter((array)get_object_vars($this),
         function ($val){
@@ -197,9 +201,16 @@ class CustomerProfileType extends CustomerProfileBaseType implements \JsonSerial
         else{
             return array_merge(parent::jsonSerialize(), $values);
         }
-    }
-    
-    // Json Set Code
+    } 
+
+    /**
+     * Json Set Code
+     * 
+     * @param $data
+     * @throws \Exception
+     *
+     * @return void
+     */
     public function set($data)
     {
         if(is_array($data) || is_object($data)) {

--- a/lib/net/authorize/api/contract/v1/CustomerType.php
+++ b/lib/net/authorize/api/contract/v1/CustomerType.php
@@ -201,7 +201,11 @@ class CustomerType implements \JsonSerializable
     }
 
 
-    // Json Serialize Code
+    /**
+     * Json Serialize Code
+     * 
+     * @return array|mixed
+     */
     public function jsonSerialize(){
         $values = array_filter((array)get_object_vars($this),
         function ($val){
@@ -234,9 +238,16 @@ class CustomerType implements \JsonSerializable
         else{
             return array_merge(parent::jsonSerialize(), $values);
         }
-    }
-    
-    // Json Set Code
+    } 
+
+    /**
+     * Json Set Code
+     * 
+     * @param $data
+     * @throws \Exception
+     *
+     * @return void
+     */
     public function set($data)
     {
         if(is_array($data) || is_object($data)) {

--- a/lib/net/authorize/api/contract/v1/DecryptPaymentDataRequest.php
+++ b/lib/net/authorize/api/contract/v1/DecryptPaymentDataRequest.php
@@ -63,7 +63,11 @@ class DecryptPaymentDataRequest extends ANetApiRequestType
     }
 
 
-    // Json Serialize Code
+    /**
+     * Json Serialize Code
+     *
+     * @return array|mixed
+     */
     public function jsonSerialize(){
         $values = array_filter((array)get_object_vars($this),
         function ($val){

--- a/lib/net/authorize/api/contract/v1/DecryptPaymentDataResponse.php
+++ b/lib/net/authorize/api/contract/v1/DecryptPaymentDataResponse.php
@@ -114,10 +114,16 @@ class DecryptPaymentDataResponse extends ANetApiResponseType
     {
         $this->paymentDetails = $paymentDetails;
         return $this;
-    }
+    } 
 
-
-    // Json Set Code
+    /**
+     * Json Set Code
+     * 
+     * @param $data
+     * @throws \Exception
+     *
+     * @return void
+     */
     public function set($data)
     {
         if(is_array($data) || is_object($data)) {

--- a/lib/net/authorize/api/contract/v1/DeleteCustomerPaymentProfileRequest.php
+++ b/lib/net/authorize/api/contract/v1/DeleteCustomerPaymentProfileRequest.php
@@ -63,7 +63,11 @@ class DeleteCustomerPaymentProfileRequest extends ANetApiRequestType
     }
 
 
-    // Json Serialize Code
+    /**
+     * Json Serialize Code
+     * 
+     * @return array|mixed
+     */
     public function jsonSerialize(){
         $values = array_filter((array)get_object_vars($this),
         function ($val){

--- a/lib/net/authorize/api/contract/v1/DeleteCustomerPaymentProfileResponse.php
+++ b/lib/net/authorize/api/contract/v1/DeleteCustomerPaymentProfileResponse.php
@@ -6,10 +6,16 @@ namespace net\authorize\api\contract\v1;
  * Class representing DeleteCustomerPaymentProfileResponse
  */
 class DeleteCustomerPaymentProfileResponse extends ANetApiResponseType
-{
+{ 
 
-
-    // Json Set Code
+    /**
+     * Json Set Code
+     * 
+     * @param $data
+     * @throws \Exception
+     *
+     * @return void
+     */
     public function set($data)
     {
         if(is_array($data) || is_object($data)) {

--- a/lib/net/authorize/api/contract/v1/DeleteCustomerProfileRequest.php
+++ b/lib/net/authorize/api/contract/v1/DeleteCustomerProfileRequest.php
@@ -36,7 +36,11 @@ class DeleteCustomerProfileRequest extends ANetApiRequestType
     }
 
 
-    // Json Serialize Code
+    /**
+     * Json Serialize Code
+     *
+     * @return array|mixed
+     */
     public function jsonSerialize(){
         $values = array_filter((array)get_object_vars($this),
         function ($val){

--- a/lib/net/authorize/api/contract/v1/DeleteCustomerProfileResponse.php
+++ b/lib/net/authorize/api/contract/v1/DeleteCustomerProfileResponse.php
@@ -8,8 +8,14 @@ namespace net\authorize\api\contract\v1;
 class DeleteCustomerProfileResponse extends ANetApiResponseType
 {
 
-
-    // Json Set Code
+    /**
+     * Json Set Code
+     *
+     * @param $data
+     * @throws \Exception
+     *
+     * @return void
+     */
     public function set($data)
     {
         if(is_array($data) || is_object($data)) {

--- a/lib/net/authorize/api/contract/v1/DeleteCustomerShippingAddressRequest.php
+++ b/lib/net/authorize/api/contract/v1/DeleteCustomerShippingAddressRequest.php
@@ -63,7 +63,11 @@ class DeleteCustomerShippingAddressRequest extends ANetApiRequestType
     }
 
 
-    // Json Serialize Code
+    /**
+     * Json Serialize Code
+     *
+     * @return array|mixed
+     */
     public function jsonSerialize(){
         $values = array_filter((array)get_object_vars($this),
         function ($val){

--- a/lib/net/authorize/api/contract/v1/DeleteCustomerShippingAddressResponse.php
+++ b/lib/net/authorize/api/contract/v1/DeleteCustomerShippingAddressResponse.php
@@ -6,10 +6,16 @@ namespace net\authorize\api\contract\v1;
  * Class representing DeleteCustomerShippingAddressResponse
  */
 class DeleteCustomerShippingAddressResponse extends ANetApiResponseType
-{
+{ 
 
-
-    // Json Set Code
+    /**
+     * Json Set Code
+     * 
+     * @param $data
+     * @throws \Exception
+     *
+     * @return void
+     */
     public function set($data)
     {
         if(is_array($data) || is_object($data)) {

--- a/lib/net/authorize/api/contract/v1/DriversLicenseMaskedType.php
+++ b/lib/net/authorize/api/contract/v1/DriversLicenseMaskedType.php
@@ -93,7 +93,11 @@ class DriversLicenseMaskedType implements \JsonSerializable
     }
 
 
-    // Json Serialize Code
+    /**
+     * Json Serialize Code
+     * 
+     * @return array|mixed
+     */
     public function jsonSerialize(){
         $values = array_filter((array)get_object_vars($this),
         function ($val){
@@ -126,9 +130,16 @@ class DriversLicenseMaskedType implements \JsonSerializable
         else{
             return array_merge(parent::jsonSerialize(), $values);
         }
-    }
-    
-    // Json Set Code
+    } 
+
+    /**
+     * Json Set Code
+     * 
+     * @param $data
+     * @throws \Exception
+     *
+     * @return void
+     */
     public function set($data)
     {
         if(is_array($data) || is_object($data)) {

--- a/lib/net/authorize/api/contract/v1/DriversLicenseType.php
+++ b/lib/net/authorize/api/contract/v1/DriversLicenseType.php
@@ -93,7 +93,11 @@ class DriversLicenseType implements \JsonSerializable
     }
 
 
-    // Json Serialize Code
+    /**
+     * Json Serialize Code
+     * 
+     * @return array|mixed
+     */
     public function jsonSerialize(){
         $values = array_filter((array)get_object_vars($this),
         function ($val){
@@ -126,9 +130,16 @@ class DriversLicenseType implements \JsonSerializable
         else{
             return array_merge(parent::jsonSerialize(), $values);
         }
-    }
-    
-    // Json Set Code
+    } 
+
+    /**
+     * Json Set Code
+     * 
+     * @param $data
+     * @throws \Exception
+     *
+     * @return void
+     */
     public function set($data)
     {
         if(is_array($data) || is_object($data)) {

--- a/lib/net/authorize/api/contract/v1/EmailSettingsType.php
+++ b/lib/net/authorize/api/contract/v1/EmailSettingsType.php
@@ -39,7 +39,11 @@ class EmailSettingsType extends ArrayOfSettingType implements \JsonSerializable
     }
 
 
-    // Json Serialize Code
+    /**
+     * Json Serialize Code
+     *
+     * @return array|mixed
+     */
     public function jsonSerialize(){
         $values = array_filter((array)get_object_vars($this),
         function ($val){
@@ -73,8 +77,15 @@ class EmailSettingsType extends ArrayOfSettingType implements \JsonSerializable
             return array_merge(parent::jsonSerialize(), $values);
         }
     }
-    
-    // Json Set Code
+
+    /**
+     * Json Set Code
+     *
+     * @param $data
+     * @throws \Exception
+     *
+     * @return void
+     */
     public function set($data)
     {
         if(is_array($data) || is_object($data)) {

--- a/lib/net/authorize/api/contract/v1/EmvTagType.php
+++ b/lib/net/authorize/api/contract/v1/EmvTagType.php
@@ -93,7 +93,11 @@ class EmvTagType implements \JsonSerializable
     }
 
 
-    // Json Serialize Code
+    /**
+     * Json Serialize Code
+     * 
+     * @return array|mixed
+     */
     public function jsonSerialize(){
         $values = array_filter((array)get_object_vars($this),
         function ($val){
@@ -126,9 +130,16 @@ class EmvTagType implements \JsonSerializable
         else{
             return array_merge(parent::jsonSerialize(), $values);
         }
-    }
-    
-    // Json Set Code
+    } 
+
+    /**
+     * Json Set Code
+     * 
+     * @param $data
+     * @throws \Exception
+     *
+     * @return void
+     */
     public function set($data)
     {
         if(is_array($data) || is_object($data)) {

--- a/lib/net/authorize/api/contract/v1/EncryptedTrackDataType.php
+++ b/lib/net/authorize/api/contract/v1/EncryptedTrackDataType.php
@@ -39,7 +39,11 @@ class EncryptedTrackDataType implements \JsonSerializable
     }
 
 
-    // Json Serialize Code
+    /**
+     * Json Serialize Code
+     *
+     * @return array|mixed
+     */
     public function jsonSerialize(){
         $values = array_filter((array)get_object_vars($this),
         function ($val){
@@ -73,8 +77,15 @@ class EncryptedTrackDataType implements \JsonSerializable
             return array_merge(parent::jsonSerialize(), $values);
         }
     }
-    
-    // Json Set Code
+
+    /**
+     * Json Set Code
+     *
+     * @param $data
+     * @throws \Exception
+     *
+     * @return void
+     */
     public function set($data)
     {
         if(is_array($data) || is_object($data)) {

--- a/lib/net/authorize/api/contract/v1/ErrorResponse.php
+++ b/lib/net/authorize/api/contract/v1/ErrorResponse.php
@@ -8,8 +8,14 @@ namespace net\authorize\api\contract\v1;
 class ErrorResponse extends ANetApiResponseType
 {
 
-
-    // Json Set Code
+    /**
+     * Json Set Code
+     *
+     * @param $data
+     * @throws \Exception
+     *
+     * @return void
+     */
     public function set($data)
     {
         if(is_array($data) || is_object($data)) {

--- a/lib/net/authorize/api/contract/v1/ExtendedAmountType.php
+++ b/lib/net/authorize/api/contract/v1/ExtendedAmountType.php
@@ -93,7 +93,11 @@ class ExtendedAmountType implements \JsonSerializable
     }
 
 
-    // Json Serialize Code
+    /**
+     * Json Serialize Code
+     * 
+     * @return array|mixed
+     */
     public function jsonSerialize(){
         $values = array_filter((array)get_object_vars($this),
         function ($val){
@@ -126,9 +130,16 @@ class ExtendedAmountType implements \JsonSerializable
         else{
             return array_merge(parent::jsonSerialize(), $values);
         }
-    }
-    
-    // Json Set Code
+    } 
+
+    /**
+     * Json Set Code
+     * 
+     * @param $data
+     * @throws \Exception
+     *
+     * @return void
+     */
     public function set($data)
     {
         if(is_array($data) || is_object($data)) {

--- a/lib/net/authorize/api/contract/v1/FDSFilterType.php
+++ b/lib/net/authorize/api/contract/v1/FDSFilterType.php
@@ -66,7 +66,11 @@ class FDSFilterType implements \JsonSerializable
     }
 
 
-    // Json Serialize Code
+    /**
+     * Json Serialize Code
+     *
+     * @return array|mixed
+     */
     public function jsonSerialize(){
         $values = array_filter((array)get_object_vars($this),
         function ($val){
@@ -100,8 +104,15 @@ class FDSFilterType implements \JsonSerializable
             return array_merge(parent::jsonSerialize(), $values);
         }
     }
-    
-    // Json Set Code
+
+    /**
+     * Json Set Code
+     *
+     * @param $data
+     * @throws \Exception
+     *
+     * @return void
+     */
     public function set($data)
     {
         if(is_array($data) || is_object($data)) {

--- a/lib/net/authorize/api/contract/v1/FingerPrintType.php
+++ b/lib/net/authorize/api/contract/v1/FingerPrintType.php
@@ -147,7 +147,11 @@ class FingerPrintType implements \JsonSerializable
     }
 
 
-    // Json Serialize Code
+    /**
+     * Json Serialize Code
+     *
+     * @return array|mixed
+     */
     public function jsonSerialize(){
         $values = array_filter((array)get_object_vars($this),
         function ($val){
@@ -181,8 +185,15 @@ class FingerPrintType implements \JsonSerializable
             return array_merge(parent::jsonSerialize(), $values);
         }
     }
-    
-    // Json Set Code
+
+    /**
+     * Json Set Code
+     *
+     * @param $data
+     * @throws \Exception
+     *
+     * @return void
+     */
     public function set($data)
     {
         if(is_array($data) || is_object($data)) {

--- a/lib/net/authorize/api/contract/v1/FraudInformationType.php
+++ b/lib/net/authorize/api/contract/v1/FraudInformationType.php
@@ -100,7 +100,11 @@ class FraudInformationType implements \JsonSerializable
     }
 
 
-    // Json Serialize Code
+    /**
+     * Json Serialize Code
+     * 
+     * @return array|mixed
+     */
     public function jsonSerialize(){
         $values = array_filter((array)get_object_vars($this),
         function ($val){
@@ -133,9 +137,16 @@ class FraudInformationType implements \JsonSerializable
         else{
             return array_merge(parent::jsonSerialize(), $values);
         }
-    }
-    
-    // Json Set Code
+    } 
+
+    /**
+     * Json Set Code
+     * 
+     * @param $data
+     * @throws \Exception
+     *
+     * @return void
+     */
     public function set($data)
     {
         if(is_array($data) || is_object($data)) {

--- a/lib/net/authorize/api/contract/v1/GetAUJobDetailsRequest.php
+++ b/lib/net/authorize/api/contract/v1/GetAUJobDetailsRequest.php
@@ -90,7 +90,11 @@ class GetAUJobDetailsRequest extends ANetApiRequestType
     }
 
 
-    // Json Serialize Code
+    /**
+     * Json Serialize Code
+     *
+     * @return array|mixed
+     */
     public function jsonSerialize(){
         $values = array_filter((array)get_object_vars($this),
         function ($val){

--- a/lib/net/authorize/api/contract/v1/GetAUJobDetailsResponse.php
+++ b/lib/net/authorize/api/contract/v1/GetAUJobDetailsResponse.php
@@ -62,8 +62,14 @@ class GetAUJobDetailsResponse extends ANetApiResponseType
         return $this;
     }
 
-
-    // Json Set Code
+    /**
+     * Json Set Code
+     *
+     * @param $data
+     * @throws \Exception
+     *
+     * @return void
+     */
     public function set($data)
     {
         if(is_array($data) || is_object($data)) {

--- a/lib/net/authorize/api/contract/v1/GetAUJobSummaryRequest.php
+++ b/lib/net/authorize/api/contract/v1/GetAUJobSummaryRequest.php
@@ -36,7 +36,11 @@ class GetAUJobSummaryRequest extends ANetApiRequestType
     }
 
 
-    // Json Serialize Code
+    /**
+     * Json Serialize Code
+     * 
+     * @return array|mixed
+     */
     public function jsonSerialize(){
         $values = array_filter((array)get_object_vars($this),
         function ($val){

--- a/lib/net/authorize/api/contract/v1/GetAUJobSummaryResponse.php
+++ b/lib/net/authorize/api/contract/v1/GetAUJobSummaryResponse.php
@@ -69,8 +69,14 @@ class GetAUJobSummaryResponse extends ANetApiResponseType
         return $this;
     }
 
-
-    // Json Set Code
+    /**
+     * Json Set Code
+     *
+     * @param $data
+     * @throws \Exception
+     *
+     * @return void
+     */
     public function set($data)
     {
         if(is_array($data) || is_object($data)) {

--- a/lib/net/authorize/api/contract/v1/GetBatchStatisticsRequest.php
+++ b/lib/net/authorize/api/contract/v1/GetBatchStatisticsRequest.php
@@ -36,7 +36,11 @@ class GetBatchStatisticsRequest extends ANetApiRequestType
     }
 
 
-    // Json Serialize Code
+    /**
+     * Json Serialize Code
+     *
+     * @return array|mixed
+     */
     public function jsonSerialize(){
         $values = array_filter((array)get_object_vars($this),
         function ($val){

--- a/lib/net/authorize/api/contract/v1/GetBatchStatisticsResponse.php
+++ b/lib/net/authorize/api/contract/v1/GetBatchStatisticsResponse.php
@@ -33,10 +33,16 @@ class GetBatchStatisticsResponse extends ANetApiResponseType
     {
         $this->batch = $batch;
         return $this;
-    }
+    } 
 
-
-    // Json Set Code
+    /**
+     * Json Set Code
+     * 
+     * @param $data
+     * @throws \Exception
+     *
+     * @return void
+     */
     public function set($data)
     {
         if(is_array($data) || is_object($data)) {

--- a/lib/net/authorize/api/contract/v1/GetCustomerPaymentProfileListRequest.php
+++ b/lib/net/authorize/api/contract/v1/GetCustomerPaymentProfileListRequest.php
@@ -118,7 +118,11 @@ class GetCustomerPaymentProfileListRequest extends ANetApiRequestType
     }
 
 
-    // Json Serialize Code
+    /**
+     * Json Serialize Code
+     *
+     * @return array|mixed
+     */
     public function jsonSerialize(){
         $values = array_filter((array)get_object_vars($this),
         function ($val){

--- a/lib/net/authorize/api/contract/v1/GetCustomerPaymentProfileListResponse.php
+++ b/lib/net/authorize/api/contract/v1/GetCustomerPaymentProfileListResponse.php
@@ -97,10 +97,16 @@ class GetCustomerPaymentProfileListResponse extends ANetApiResponseType
     {
         $this->paymentProfiles = $paymentProfiles;
         return $this;
-    }
+    } 
 
-
-    // Json Set Code
+    /**
+     * Json Set Code
+     * 
+     * @param $data
+     * @throws \Exception
+     *
+     * @return void
+     */
     public function set($data)
     {
         if(is_array($data) || is_object($data)) {

--- a/lib/net/authorize/api/contract/v1/GetCustomerPaymentProfileRequest.php
+++ b/lib/net/authorize/api/contract/v1/GetCustomerPaymentProfileRequest.php
@@ -117,7 +117,11 @@ class GetCustomerPaymentProfileRequest extends ANetApiRequestType
     }
 
 
-    // Json Serialize Code
+    /**
+     * Json Serialize Code
+     * 
+     * @return array|mixed
+     */
     public function jsonSerialize(){
         $values = array_filter((array)get_object_vars($this),
         function ($val){

--- a/lib/net/authorize/api/contract/v1/GetCustomerPaymentProfileResponse.php
+++ b/lib/net/authorize/api/contract/v1/GetCustomerPaymentProfileResponse.php
@@ -37,8 +37,14 @@ class GetCustomerPaymentProfileResponse extends ANetApiResponseType
         return $this;
     }
 
-
-    // Json Set Code
+    /**
+     * Json Set Code
+     *
+     * @param $data
+     * @throws \Exception
+     *
+     * @return void
+     */
     public function set($data)
     {
         if(is_array($data) || is_object($data)) {

--- a/lib/net/authorize/api/contract/v1/GetCustomerProfileIdsRequest.php
+++ b/lib/net/authorize/api/contract/v1/GetCustomerProfileIdsRequest.php
@@ -9,7 +9,11 @@ class GetCustomerProfileIdsRequest extends ANetApiRequestType
 {
 
 
-    // Json Serialize Code
+    /**
+     * Json Serialize Code
+     *
+     * @return array|mixed
+     */
     public function jsonSerialize(){
         $values = array_filter((array)get_object_vars($this),
         function ($val){

--- a/lib/net/authorize/api/contract/v1/GetCustomerProfileIdsResponse.php
+++ b/lib/net/authorize/api/contract/v1/GetCustomerProfileIdsResponse.php
@@ -69,8 +69,14 @@ class GetCustomerProfileIdsResponse extends ANetApiResponseType
         return $this;
     }
 
-
-    // Json Set Code
+    /**
+     * Json Set Code
+     *
+     * @param $data
+     * @throws \Exception
+     *
+     * @return void
+     */
     public function set($data)
     {
         if(is_array($data) || is_object($data)) {

--- a/lib/net/authorize/api/contract/v1/GetCustomerProfileRequest.php
+++ b/lib/net/authorize/api/contract/v1/GetCustomerProfileRequest.php
@@ -144,7 +144,11 @@ class GetCustomerProfileRequest extends ANetApiRequestType
     }
 
 
-    // Json Serialize Code
+    /**
+     * Json Serialize Code
+     * 
+     * @return array|mixed
+     */
     public function jsonSerialize(){
         $values = array_filter((array)get_object_vars($this),
         function ($val){

--- a/lib/net/authorize/api/contract/v1/GetCustomerProfileResponse.php
+++ b/lib/net/authorize/api/contract/v1/GetCustomerProfileResponse.php
@@ -94,10 +94,16 @@ class GetCustomerProfileResponse extends ANetApiResponseType
     {
         $this->subscriptionIds = $subscriptionIds;
         return $this;
-    }
+    } 
 
-
-    // Json Set Code
+    /**
+     * Json Set Code
+     * 
+     * @param $data
+     * @throws \Exception
+     *
+     * @return void
+     */
     public function set($data)
     {
         if(is_array($data) || is_object($data)) {

--- a/lib/net/authorize/api/contract/v1/GetCustomerShippingAddressRequest.php
+++ b/lib/net/authorize/api/contract/v1/GetCustomerShippingAddressRequest.php
@@ -63,7 +63,11 @@ class GetCustomerShippingAddressRequest extends ANetApiRequestType
     }
 
 
-    // Json Serialize Code
+    /**
+     * Json Serialize Code
+     *
+     * @return array|mixed
+     */
     public function jsonSerialize(){
         $values = array_filter((array)get_object_vars($this),
         function ($val){

--- a/lib/net/authorize/api/contract/v1/GetCustomerShippingAddressResponse.php
+++ b/lib/net/authorize/api/contract/v1/GetCustomerShippingAddressResponse.php
@@ -121,10 +121,16 @@ class GetCustomerShippingAddressResponse extends ANetApiResponseType
     {
         $this->subscriptionIds = $subscriptionIds;
         return $this;
-    }
+    } 
 
-
-    // Json Set Code
+    /**
+     * Json Set Code
+     * 
+     * @param $data
+     * @throws \Exception
+     *
+     * @return void
+     */
     public function set($data)
     {
         if(is_array($data) || is_object($data)) {

--- a/lib/net/authorize/api/contract/v1/GetHostedPaymentPageRequest.php
+++ b/lib/net/authorize/api/contract/v1/GetHostedPaymentPageRequest.php
@@ -140,7 +140,11 @@ class GetHostedPaymentPageRequest extends ANetApiRequestType
     }
 
 
-    // Json Serialize Code
+    /**
+     * Json Serialize Code
+     *
+     * @return array|mixed
+     */
     public function jsonSerialize(){
         $values = array_filter((array)get_object_vars($this),
         function ($val){

--- a/lib/net/authorize/api/contract/v1/GetHostedPaymentPageResponse.php
+++ b/lib/net/authorize/api/contract/v1/GetHostedPaymentPageResponse.php
@@ -33,10 +33,16 @@ class GetHostedPaymentPageResponse extends ANetApiResponseType
     {
         $this->token = $token;
         return $this;
-    }
+    } 
 
-
-    // Json Set Code
+    /**
+     * Json Set Code
+     * 
+     * @param $data
+     * @throws \Exception
+     *
+     * @return void
+     */
     public function set($data)
     {
         if(is_array($data) || is_object($data)) {

--- a/lib/net/authorize/api/contract/v1/GetHostedProfilePageRequest.php
+++ b/lib/net/authorize/api/contract/v1/GetHostedProfilePageRequest.php
@@ -139,7 +139,11 @@ class GetHostedProfilePageRequest extends ANetApiRequestType
     }
 
 
-    // Json Serialize Code
+    /**
+     * Json Serialize Code
+     * 
+     * @return array|mixed
+     */
     public function jsonSerialize(){
         $values = array_filter((array)get_object_vars($this),
         function ($val){

--- a/lib/net/authorize/api/contract/v1/GetHostedProfilePageResponse.php
+++ b/lib/net/authorize/api/contract/v1/GetHostedProfilePageResponse.php
@@ -33,10 +33,16 @@ class GetHostedProfilePageResponse extends ANetApiResponseType
     {
         $this->token = $token;
         return $this;
-    }
+    } 
 
-
-    // Json Set Code
+    /**
+     * Json Set Code
+     * 
+     * @param $data
+     * @throws \Exception
+     *
+     * @return void
+     */
     public function set($data)
     {
         if(is_array($data) || is_object($data)) {

--- a/lib/net/authorize/api/contract/v1/GetMerchantDetailsRequest.php
+++ b/lib/net/authorize/api/contract/v1/GetMerchantDetailsRequest.php
@@ -9,7 +9,11 @@ class GetMerchantDetailsRequest extends ANetApiRequestType
 {
 
 
-    // Json Serialize Code
+    /**
+     * Json Serialize Code
+     *
+     * @return array|mixed
+     */
     public function jsonSerialize(){
         $values = array_filter((array)get_object_vars($this),
         function ($val){

--- a/lib/net/authorize/api/contract/v1/GetMerchantDetailsResponse.php
+++ b/lib/net/authorize/api/contract/v1/GetMerchantDetailsResponse.php
@@ -419,10 +419,16 @@ class GetMerchantDetailsResponse extends ANetApiResponseType
     {
         $this->publicClientKey = $publicClientKey;
         return $this;
-    }
+    } 
 
-
-    // Json Set Code
+    /**
+     * Json Set Code
+     * 
+     * @param $data
+     * @throws \Exception
+     *
+     * @return void
+     */
     public function set($data)
     {
         if(is_array($data) || is_object($data)) {

--- a/lib/net/authorize/api/contract/v1/GetSettledBatchListRequest.php
+++ b/lib/net/authorize/api/contract/v1/GetSettledBatchListRequest.php
@@ -90,7 +90,11 @@ class GetSettledBatchListRequest extends ANetApiRequestType
     }
 
 
-    // Json Serialize Code
+    /**
+     * Json Serialize Code
+     *
+     * @return array|mixed
+     */
     public function jsonSerialize(){
         $values = array_filter((array)get_object_vars($this),
         function ($val){

--- a/lib/net/authorize/api/contract/v1/GetSettledBatchListResponse.php
+++ b/lib/net/authorize/api/contract/v1/GetSettledBatchListResponse.php
@@ -67,10 +67,16 @@ class GetSettledBatchListResponse extends ANetApiResponseType
     {
         $this->batchList = $batchList;
         return $this;
-    }
+    } 
 
-
-    // Json Set Code
+    /**
+     * Json Set Code
+     * 
+     * @param $data
+     * @throws \Exception
+     *
+     * @return void
+     */
     public function set($data)
     {
         if(is_array($data) || is_object($data)) {

--- a/lib/net/authorize/api/contract/v1/GetTransactionDetailsRequest.php
+++ b/lib/net/authorize/api/contract/v1/GetTransactionDetailsRequest.php
@@ -36,7 +36,11 @@ class GetTransactionDetailsRequest extends ANetApiRequestType
     }
 
 
-    // Json Serialize Code
+    /**
+     * Json Serialize Code
+     * 
+     * @return array|mixed
+     */
     public function jsonSerialize(){
         $values = array_filter((array)get_object_vars($this),
         function ($val){

--- a/lib/net/authorize/api/contract/v1/GetTransactionDetailsResponse.php
+++ b/lib/net/authorize/api/contract/v1/GetTransactionDetailsResponse.php
@@ -87,10 +87,16 @@ class GetTransactionDetailsResponse extends ANetApiResponseType
     {
         $this->transrefId = $transrefId;
         return $this;
-    }
+    } 
 
-
-    // Json Set Code
+    /**
+     * Json Set Code
+     * 
+     * @param $data
+     * @throws \Exception
+     *
+     * @return void
+     */
     public function set($data)
     {
         if(is_array($data) || is_object($data)) {

--- a/lib/net/authorize/api/contract/v1/GetTransactionListForCustomerRequest.php
+++ b/lib/net/authorize/api/contract/v1/GetTransactionListForCustomerRequest.php
@@ -117,7 +117,11 @@ class GetTransactionListForCustomerRequest extends ANetApiRequestType
     }
 
 
-    // Json Serialize Code
+    /**
+     * Json Serialize Code
+     * 
+     * @return array|mixed
+     */
     public function jsonSerialize(){
         $values = array_filter((array)get_object_vars($this),
         function ($val){

--- a/lib/net/authorize/api/contract/v1/GetTransactionListRequest.php
+++ b/lib/net/authorize/api/contract/v1/GetTransactionListRequest.php
@@ -90,7 +90,11 @@ class GetTransactionListRequest extends ANetApiRequestType
     }
 
 
-    // Json Serialize Code
+    /**
+     * Json Serialize Code
+     *
+     * @return array|mixed
+     */
     public function jsonSerialize(){
         $values = array_filter((array)get_object_vars($this),
         function ($val){

--- a/lib/net/authorize/api/contract/v1/GetTransactionListResponse.php
+++ b/lib/net/authorize/api/contract/v1/GetTransactionListResponse.php
@@ -96,8 +96,14 @@ class GetTransactionListResponse extends ANetApiResponseType
         return $this;
     }
 
-
-    // Json Set Code
+    /**
+     * Json Set Code
+     *
+     * @param $data
+     * @throws \Exception
+     *
+     * @return void
+     */
     public function set($data)
     {
         if(is_array($data) || is_object($data)) {

--- a/lib/net/authorize/api/contract/v1/GetUnsettledTransactionListRequest.php
+++ b/lib/net/authorize/api/contract/v1/GetUnsettledTransactionListRequest.php
@@ -90,7 +90,11 @@ class GetUnsettledTransactionListRequest extends ANetApiRequestType
     }
 
 
-    // Json Serialize Code
+    /**
+     * Json Serialize Code
+     * 
+     * @return array|mixed
+     */
     public function jsonSerialize(){
         $values = array_filter((array)get_object_vars($this),
         function ($val){

--- a/lib/net/authorize/api/contract/v1/GetUnsettledTransactionListResponse.php
+++ b/lib/net/authorize/api/contract/v1/GetUnsettledTransactionListResponse.php
@@ -96,8 +96,14 @@ class GetUnsettledTransactionListResponse extends ANetApiResponseType
         return $this;
     }
 
-
-    // Json Set Code
+    /**
+     * Json Set Code
+     *
+     * @param $data
+     * @throws \Exception
+     *
+     * @return void
+     */
     public function set($data)
     {
         if(is_array($data) || is_object($data)) {

--- a/lib/net/authorize/api/contract/v1/HeldTransactionRequestType.php
+++ b/lib/net/authorize/api/contract/v1/HeldTransactionRequestType.php
@@ -66,7 +66,11 @@ class HeldTransactionRequestType implements \JsonSerializable
     }
 
 
-    // Json Serialize Code
+    /**
+     * Json Serialize Code
+     * 
+     * @return array|mixed
+     */
     public function jsonSerialize(){
         $values = array_filter((array)get_object_vars($this),
         function ($val){
@@ -99,9 +103,16 @@ class HeldTransactionRequestType implements \JsonSerializable
         else{
             return array_merge(parent::jsonSerialize(), $values);
         }
-    }
-    
-    // Json Set Code
+    } 
+
+    /**
+     * Json Set Code
+     * 
+     * @param $data
+     * @throws \Exception
+     *
+     * @return void
+     */
     public function set($data)
     {
         if(is_array($data) || is_object($data)) {

--- a/lib/net/authorize/api/contract/v1/ImpersonationAuthenticationType.php
+++ b/lib/net/authorize/api/contract/v1/ImpersonationAuthenticationType.php
@@ -66,7 +66,11 @@ class ImpersonationAuthenticationType implements \JsonSerializable
     }
 
 
-    // Json Serialize Code
+    /**
+     * Json Serialize Code
+     * 
+     * @return array|mixed
+     */
     public function jsonSerialize(){
         $values = array_filter((array)get_object_vars($this),
         function ($val){
@@ -99,9 +103,16 @@ class ImpersonationAuthenticationType implements \JsonSerializable
         else{
             return array_merge(parent::jsonSerialize(), $values);
         }
-    }
-    
-    // Json Set Code
+    } 
+
+    /**
+     * Json Set Code
+     * 
+     * @param $data
+     * @throws \Exception
+     *
+     * @return void
+     */
     public function set($data)
     {
         if(is_array($data) || is_object($data)) {

--- a/lib/net/authorize/api/contract/v1/IsAliveRequest.php
+++ b/lib/net/authorize/api/contract/v1/IsAliveRequest.php
@@ -36,7 +36,11 @@ class IsAliveRequest
     }
 
 
-    // Json Serialize Code
+    /**
+     * Json Serialize Code
+     * 
+     * @return array|mixed
+     */
     public function jsonSerialize(){
         $values = array_filter((array)get_object_vars($this),
         function ($val){

--- a/lib/net/authorize/api/contract/v1/IsAliveResponse.php
+++ b/lib/net/authorize/api/contract/v1/IsAliveResponse.php
@@ -8,8 +8,14 @@ namespace net\authorize\api\contract\v1;
 class IsAliveResponse extends ANetApiResponseType
 {
 
-
-    // Json Set Code
+    /**
+     * Json Set Code
+     *
+     * @param $data
+     * @throws \Exception
+     *
+     * @return void
+     */
     public function set($data)
     {
         if(is_array($data) || is_object($data)) {

--- a/lib/net/authorize/api/contract/v1/KeyBlockType.php
+++ b/lib/net/authorize/api/contract/v1/KeyBlockType.php
@@ -39,7 +39,11 @@ class KeyBlockType implements \JsonSerializable
     }
 
 
-    // Json Serialize Code
+    /**
+     * Json Serialize Code
+     * 
+     * @return array|mixed
+     */
     public function jsonSerialize(){
         $values = array_filter((array)get_object_vars($this),
         function ($val){
@@ -72,9 +76,16 @@ class KeyBlockType implements \JsonSerializable
         else{
             return array_merge(parent::jsonSerialize(), $values);
         }
-    }
-    
-    // Json Set Code
+    } 
+
+    /**
+     * Json Set Code
+     * 
+     * @param $data
+     * @throws \Exception
+     *
+     * @return void
+     */
     public function set($data)
     {
         if(is_array($data) || is_object($data)) {

--- a/lib/net/authorize/api/contract/v1/KeyManagementSchemeType.php
+++ b/lib/net/authorize/api/contract/v1/KeyManagementSchemeType.php
@@ -40,7 +40,11 @@ class KeyManagementSchemeType implements \JsonSerializable
     }
 
 
-    // Json Serialize Code
+    /**
+     * Json Serialize Code
+     *
+     * @return array|mixed
+     */
     public function jsonSerialize(){
         $values = array_filter((array)get_object_vars($this),
         function ($val){
@@ -74,8 +78,15 @@ class KeyManagementSchemeType implements \JsonSerializable
             return array_merge(parent::jsonSerialize(), $values);
         }
     }
-    
-    // Json Set Code
+
+    /**
+     * Json Set Code
+     *
+     * @param $data
+     * @throws \Exception
+     *
+     * @return void
+     */
     public function set($data)
     {
         if(is_array($data) || is_object($data)) {

--- a/lib/net/authorize/api/contract/v1/KeyManagementSchemeType/DUKPTAType.php
+++ b/lib/net/authorize/api/contract/v1/KeyManagementSchemeType/DUKPTAType.php
@@ -132,7 +132,11 @@ class DUKPTAType implements \JsonSerializable
     }
 
 
-    // Json Serialize Code
+    /**
+     * Json Serialize Code
+     * 
+     * @return array|mixed
+     */
     public function jsonSerialize(){
         $values = array_filter((array)get_object_vars($this),
         function ($val){
@@ -165,9 +169,16 @@ class DUKPTAType implements \JsonSerializable
         else{
             return array_merge(parent::jsonSerialize(), $values);
         }
-    }
-    
-    // Json Set Code
+    } 
+
+    /**
+     * Json Set Code
+     * 
+     * @param $data
+     * @throws \Exception
+     *
+     * @return void
+     */
     public function set($data)
     {
         if(is_array($data) || is_object($data)) {

--- a/lib/net/authorize/api/contract/v1/KeyManagementSchemeType/DUKPTAType/DeviceInfoAType.php
+++ b/lib/net/authorize/api/contract/v1/KeyManagementSchemeType/DUKPTAType/DeviceInfoAType.php
@@ -36,7 +36,11 @@ class DeviceInfoAType implements \JsonSerializable
     }
 
 
-    // Json Serialize Code
+    /**
+     * Json Serialize Code
+     * 
+     * @return array|mixed
+     */
     public function jsonSerialize(){
         $values = array_filter((array)get_object_vars($this),
         function ($val){
@@ -69,9 +73,16 @@ class DeviceInfoAType implements \JsonSerializable
         else{
             return array_merge(parent::jsonSerialize(), $values);
         }
-    }
-    
-    // Json Set Code
+    } 
+
+    /**
+     * Json Set Code
+     * 
+     * @param $data
+     * @throws \Exception
+     *
+     * @return void
+     */
     public function set($data)
     {
         if(is_array($data) || is_object($data)) {

--- a/lib/net/authorize/api/contract/v1/KeyManagementSchemeType/DUKPTAType/EncryptedDataAType.php
+++ b/lib/net/authorize/api/contract/v1/KeyManagementSchemeType/DUKPTAType/EncryptedDataAType.php
@@ -36,7 +36,11 @@ class EncryptedDataAType implements \JsonSerializable
     }
 
 
-    // Json Serialize Code
+    /**
+     * Json Serialize Code
+     *
+     * @return array|mixed
+     */
     public function jsonSerialize(){
         $values = array_filter((array)get_object_vars($this),
         function ($val){
@@ -69,9 +73,16 @@ class EncryptedDataAType implements \JsonSerializable
         else{
             return array_merge(parent::jsonSerialize(), $values);
         }
-    }
-    
-    // Json Set Code
+    } 
+
+    /**
+     * Json Set Code
+     * 
+     * @param $data
+     * @throws \Exception
+     *
+     * @return void
+     */
     public function set($data)
     {
         if(is_array($data) || is_object($data)) {

--- a/lib/net/authorize/api/contract/v1/KeyManagementSchemeType/DUKPTAType/ModeAType.php
+++ b/lib/net/authorize/api/contract/v1/KeyManagementSchemeType/DUKPTAType/ModeAType.php
@@ -63,7 +63,11 @@ class ModeAType implements \JsonSerializable
     }
 
 
-    // Json Serialize Code
+    /**
+     * Json Serialize Code
+     *
+     * @return array|mixed
+     */
     public function jsonSerialize(){
         $values = array_filter((array)get_object_vars($this),
         function ($val){
@@ -97,8 +101,15 @@ class ModeAType implements \JsonSerializable
             return array_merge(parent::jsonSerialize(), $values);
         }
     }
-    
-    // Json Set Code
+
+    /**
+     * Json Set Code
+     *
+     * @param $data
+     * @throws \Exception
+     *
+     * @return void
+     */
     public function set($data)
     {
         if(is_array($data) || is_object($data)) {

--- a/lib/net/authorize/api/contract/v1/KeyValueType.php
+++ b/lib/net/authorize/api/contract/v1/KeyValueType.php
@@ -93,7 +93,11 @@ class KeyValueType implements \JsonSerializable
     }
 
 
-    // Json Serialize Code
+    /**
+     * Json Serialize Code
+     * 
+     * @return array|mixed
+     */
     public function jsonSerialize(){
         $values = array_filter((array)get_object_vars($this),
         function ($val){
@@ -126,9 +130,16 @@ class KeyValueType implements \JsonSerializable
         else{
             return array_merge(parent::jsonSerialize(), $values);
         }
-    }
-    
-    // Json Set Code
+    } 
+
+    /**
+     * Json Set Code
+     * 
+     * @param $data
+     * @throws \Exception
+     *
+     * @return void
+     */
     public function set($data)
     {
         if(is_array($data) || is_object($data)) {

--- a/lib/net/authorize/api/contract/v1/LineItemType.php
+++ b/lib/net/authorize/api/contract/v1/LineItemType.php
@@ -714,7 +714,11 @@ class LineItemType implements \JsonSerializable
     }
 
 
-    // Json Serialize Code
+    /**
+     * Json Serialize Code
+     *
+     * @return array|mixed
+     */
     public function jsonSerialize(){
         $values = array_filter((array)get_object_vars($this),
         function ($val){
@@ -748,8 +752,15 @@ class LineItemType implements \JsonSerializable
             return array_merge(parent::jsonSerialize(), $values);
         }
     }
-    
-    // Json Set Code
+
+    /**
+     * Json Set Code
+     *
+     * @param $data
+     * @throws \Exception
+     *
+     * @return void
+     */
     public function set($data)
     {
         if(is_array($data) || is_object($data)) {

--- a/lib/net/authorize/api/contract/v1/ListOfAUDetailsType.php
+++ b/lib/net/authorize/api/contract/v1/ListOfAUDetailsType.php
@@ -134,7 +134,11 @@ class ListOfAUDetailsType implements \JsonSerializable
     }
 
 
-    // Json Serialize Code
+    /**
+     * Json Serialize Code
+     * 
+     * @return array|mixed
+     */
     public function jsonSerialize(){
         $values = array_filter((array)get_object_vars($this),
         function ($val){
@@ -167,9 +171,16 @@ class ListOfAUDetailsType implements \JsonSerializable
         else{
             return array_merge(parent::jsonSerialize(), $values);
         }
-    }
-    
-    // Json Set Code
+    } 
+
+    /**
+     * Json Set Code
+     * 
+     * @param $data
+     * @throws \Exception
+     *
+     * @return void
+     */
     public function set($data)
     {
         if(is_array($data) || is_object($data)) {

--- a/lib/net/authorize/api/contract/v1/LogoutRequest.php
+++ b/lib/net/authorize/api/contract/v1/LogoutRequest.php
@@ -9,7 +9,11 @@ class LogoutRequest extends ANetApiRequestType
 {
 
 
-    // Json Serialize Code
+    /**
+     * Json Serialize Code
+     * 
+     * @return array|mixed
+     */
     public function jsonSerialize(){
         $values = array_filter((array)get_object_vars($this),
         function ($val){

--- a/lib/net/authorize/api/contract/v1/LogoutResponse.php
+++ b/lib/net/authorize/api/contract/v1/LogoutResponse.php
@@ -8,8 +8,14 @@ namespace net\authorize\api\contract\v1;
 class LogoutResponse extends ANetApiResponseType
 {
 
-
-    // Json Set Code
+    /**
+     * Json Set Code
+     *
+     * @param $data
+     * @throws \Exception
+     *
+     * @return void
+     */
     public function set($data)
     {
         if(is_array($data) || is_object($data)) {

--- a/lib/net/authorize/api/contract/v1/MerchantAuthenticationType.php
+++ b/lib/net/authorize/api/contract/v1/MerchantAuthenticationType.php
@@ -257,7 +257,11 @@ class MerchantAuthenticationType implements \JsonSerializable
     }
 
 
-    // Json Serialize Code
+    /**
+     * Json Serialize Code
+     *
+     * @return array|mixed
+     */
     public function jsonSerialize(){
         $values = array_filter((array)get_object_vars($this),
         function ($val){
@@ -291,8 +295,15 @@ class MerchantAuthenticationType implements \JsonSerializable
             return array_merge(parent::jsonSerialize(), $values);
         }
     }
-    
-    // Json Set Code
+
+    /**
+     * Json Set Code
+     *
+     * @param $data
+     * @throws \Exception
+     *
+     * @return void
+     */
     public function set($data)
     {
         if(is_array($data) || is_object($data)) {

--- a/lib/net/authorize/api/contract/v1/MerchantContactType.php
+++ b/lib/net/authorize/api/contract/v1/MerchantContactType.php
@@ -174,7 +174,11 @@ class MerchantContactType implements \JsonSerializable
     }
 
 
-    // Json Serialize Code
+    /**
+     * Json Serialize Code
+     * 
+     * @return array|mixed
+     */
     public function jsonSerialize(){
         $values = array_filter((array)get_object_vars($this),
         function ($val){
@@ -207,9 +211,16 @@ class MerchantContactType implements \JsonSerializable
         else{
             return array_merge(parent::jsonSerialize(), $values);
         }
-    }
-    
-    // Json Set Code
+    } 
+
+    /**
+     * Json Set Code
+     * 
+     * @param $data
+     * @throws \Exception
+     *
+     * @return void
+     */
     public function set($data)
     {
         if(is_array($data) || is_object($data)) {

--- a/lib/net/authorize/api/contract/v1/MessagesType.php
+++ b/lib/net/authorize/api/contract/v1/MessagesType.php
@@ -100,7 +100,11 @@ class MessagesType implements \JsonSerializable
     }
 
 
-    // Json Serialize Code
+    /**
+     * Json Serialize Code
+     * 
+     * @return array|mixed
+     */
     public function jsonSerialize(){
         $values = array_filter((array)get_object_vars($this),
         function ($val){
@@ -133,9 +137,16 @@ class MessagesType implements \JsonSerializable
         else{
             return array_merge(parent::jsonSerialize(), $values);
         }
-    }
-    
-    // Json Set Code
+    } 
+
+    /**
+     * Json Set Code
+     * 
+     * @param $data
+     * @throws \Exception
+     *
+     * @return void
+     */
     public function set($data)
     {
         if(is_array($data) || is_object($data)) {

--- a/lib/net/authorize/api/contract/v1/MessagesType/MessageAType.php
+++ b/lib/net/authorize/api/contract/v1/MessagesType/MessageAType.php
@@ -63,7 +63,11 @@ class MessageAType implements \JsonSerializable
     }
 
 
-    // Json Serialize Code
+    /**
+     * Json Serialize Code
+     * 
+     * @return array|mixed
+     */
     public function jsonSerialize(){
         $values = array_filter((array)get_object_vars($this),
         function ($val){
@@ -96,9 +100,16 @@ class MessageAType implements \JsonSerializable
         else{
             return array_merge(parent::jsonSerialize(), $values);
         }
-    }
-    
-    // Json Set Code
+    } 
+
+    /**
+     * Json Set Code
+     * 
+     * @param $data
+     * @throws \Exception
+     *
+     * @return void
+     */
     public function set($data)
     {
         if(is_array($data) || is_object($data)) {

--- a/lib/net/authorize/api/contract/v1/MobileDeviceLoginRequest.php
+++ b/lib/net/authorize/api/contract/v1/MobileDeviceLoginRequest.php
@@ -9,7 +9,11 @@ class MobileDeviceLoginRequest extends ANetApiRequestType
 {
 
 
-    // Json Serialize Code
+    /**
+     * Json Serialize Code
+     * 
+     * @return array|mixed
+     */
     public function jsonSerialize(){
         $values = array_filter((array)get_object_vars($this),
         function ($val){

--- a/lib/net/authorize/api/contract/v1/MobileDeviceLoginResponse.php
+++ b/lib/net/authorize/api/contract/v1/MobileDeviceLoginResponse.php
@@ -121,10 +121,16 @@ class MobileDeviceLoginResponse extends ANetApiResponseType
     {
         $this->merchantAccount = $merchantAccount;
         return $this;
-    }
+    } 
 
-
-    // Json Set Code
+    /**
+     * Json Set Code
+     * 
+     * @param $data
+     * @throws \Exception
+     *
+     * @return void
+     */
     public function set($data)
     {
         if(is_array($data) || is_object($data)) {

--- a/lib/net/authorize/api/contract/v1/MobileDeviceRegistrationRequest.php
+++ b/lib/net/authorize/api/contract/v1/MobileDeviceRegistrationRequest.php
@@ -36,7 +36,11 @@ class MobileDeviceRegistrationRequest extends ANetApiRequestType
     }
 
 
-    // Json Serialize Code
+    /**
+     * Json Serialize Code
+     *
+     * @return array|mixed
+     */
     public function jsonSerialize(){
         $values = array_filter((array)get_object_vars($this),
         function ($val){

--- a/lib/net/authorize/api/contract/v1/MobileDeviceRegistrationResponse.php
+++ b/lib/net/authorize/api/contract/v1/MobileDeviceRegistrationResponse.php
@@ -6,10 +6,16 @@ namespace net\authorize\api\contract\v1;
  * Class representing MobileDeviceRegistrationResponse
  */
 class MobileDeviceRegistrationResponse extends ANetApiResponseType
-{
+{ 
 
-
-    // Json Set Code
+    /**
+     * Json Set Code
+     * 
+     * @param $data
+     * @throws \Exception
+     *
+     * @return void
+     */
     public function set($data)
     {
         if(is_array($data) || is_object($data)) {

--- a/lib/net/authorize/api/contract/v1/MobileDeviceType.php
+++ b/lib/net/authorize/api/contract/v1/MobileDeviceType.php
@@ -147,7 +147,11 @@ class MobileDeviceType implements \JsonSerializable
     }
 
 
-    // Json Serialize Code
+    /**
+     * Json Serialize Code
+     *
+     * @return array|mixed
+     */
     public function jsonSerialize(){
         $values = array_filter((array)get_object_vars($this),
         function ($val){
@@ -181,8 +185,15 @@ class MobileDeviceType implements \JsonSerializable
             return array_merge(parent::jsonSerialize(), $values);
         }
     }
-    
-    // Json Set Code
+
+    /**
+     * Json Set Code
+     *
+     * @param $data
+     * @throws \Exception
+     *
+     * @return void
+     */
     public function set($data)
     {
         if(is_array($data) || is_object($data)) {

--- a/lib/net/authorize/api/contract/v1/NameAndAddressType.php
+++ b/lib/net/authorize/api/contract/v1/NameAndAddressType.php
@@ -228,7 +228,11 @@ class NameAndAddressType implements \JsonSerializable
     }
 
 
-    // Json Serialize Code
+    /**
+     * Json Serialize Code
+     * 
+     * @return array|mixed
+     */
     public function jsonSerialize(){
         $values = array_filter((array)get_object_vars($this),
         function ($val){
@@ -261,9 +265,16 @@ class NameAndAddressType implements \JsonSerializable
         else{
             return array_merge(parent::jsonSerialize(), $values);
         }
-    }
-    
-    // Json Set Code
+    } 
+
+    /**
+     * Json Set Code
+     * 
+     * @param $data
+     * @throws \Exception
+     *
+     * @return void
+     */
     public function set($data)
     {
         if(is_array($data) || is_object($data)) {

--- a/lib/net/authorize/api/contract/v1/OpaqueDataType.php
+++ b/lib/net/authorize/api/contract/v1/OpaqueDataType.php
@@ -93,7 +93,11 @@ class OpaqueDataType implements \JsonSerializable
     }
 
 
-    // Json Serialize Code
+    /**
+     * Json Serialize Code
+     * 
+     * @return array|mixed
+     */
     public function jsonSerialize(){
         $values = array_filter((array)get_object_vars($this),
         function ($val){
@@ -126,9 +130,16 @@ class OpaqueDataType implements \JsonSerializable
         else{
             return array_merge(parent::jsonSerialize(), $values);
         }
-    }
-    
-    // Json Set Code
+    } 
+
+    /**
+     * Json Set Code
+     * 
+     * @param $data
+     * @throws \Exception
+     *
+     * @return void
+     */
     public function set($data)
     {
         if(is_array($data) || is_object($data)) {

--- a/lib/net/authorize/api/contract/v1/OrderExType.php
+++ b/lib/net/authorize/api/contract/v1/OrderExType.php
@@ -39,7 +39,11 @@ class OrderExType extends OrderType implements \JsonSerializable
     }
 
 
-    // Json Serialize Code
+    /**
+     * Json Serialize Code
+     *
+     * @return array|mixed
+     */
     public function jsonSerialize(){
         $values = array_filter((array)get_object_vars($this),
         function ($val){
@@ -73,8 +77,15 @@ class OrderExType extends OrderType implements \JsonSerializable
             return array_merge(parent::jsonSerialize(), $values);
         }
     }
-    
-    // Json Set Code
+
+    /**
+     * Json Set Code
+     *
+     * @param $data
+     * @throws \Exception
+     *
+     * @return void
+     */
     public function set($data)
     {
         if(is_array($data) || is_object($data)) {

--- a/lib/net/authorize/api/contract/v1/OrderType.php
+++ b/lib/net/authorize/api/contract/v1/OrderType.php
@@ -498,7 +498,11 @@ class OrderType implements \JsonSerializable
     }
 
 
-    // Json Serialize Code
+    /**
+     * Json Serialize Code
+     * 
+     * @return array|mixed
+     */
     public function jsonSerialize(){
         $values = array_filter((array)get_object_vars($this),
         function ($val){
@@ -531,9 +535,16 @@ class OrderType implements \JsonSerializable
         else{
             return array_merge(parent::jsonSerialize(), $values);
         }
-    }
-    
-    // Json Set Code
+    } 
+
+    /**
+     * Json Set Code
+     * 
+     * @param $data
+     * @throws \Exception
+     *
+     * @return void
+     */
     public function set($data)
     {
         if(is_array($data) || is_object($data)) {

--- a/lib/net/authorize/api/contract/v1/OtherTaxType.php
+++ b/lib/net/authorize/api/contract/v1/OtherTaxType.php
@@ -174,7 +174,11 @@ class OtherTaxType implements \JsonSerializable
     }
 
 
-    // Json Serialize Code
+    /**
+     * Json Serialize Code
+     *
+     * @return array|mixed
+     */
     public function jsonSerialize(){
         $values = array_filter((array)get_object_vars($this),
         function ($val){
@@ -208,8 +212,15 @@ class OtherTaxType implements \JsonSerializable
             return array_merge(parent::jsonSerialize(), $values);
         }
     }
-    
-    // Json Set Code
+
+    /**
+     * Json Set Code
+     *
+     * @param $data
+     * @throws \Exception
+     *
+     * @return void
+     */
     public function set($data)
     {
         if(is_array($data) || is_object($data)) {

--- a/lib/net/authorize/api/contract/v1/PagingType.php
+++ b/lib/net/authorize/api/contract/v1/PagingType.php
@@ -66,7 +66,11 @@ class PagingType implements \JsonSerializable
     }
 
 
-    // Json Serialize Code
+    /**
+     * Json Serialize Code
+     * 
+     * @return array|mixed
+     */
     public function jsonSerialize(){
         $values = array_filter((array)get_object_vars($this),
         function ($val){
@@ -99,9 +103,16 @@ class PagingType implements \JsonSerializable
         else{
             return array_merge(parent::jsonSerialize(), $values);
         }
-    }
-    
-    // Json Set Code
+    } 
+
+    /**
+     * Json Set Code
+     * 
+     * @param $data
+     * @throws \Exception
+     *
+     * @return void
+     */
     public function set($data)
     {
         if(is_array($data) || is_object($data)) {

--- a/lib/net/authorize/api/contract/v1/PayPalType.php
+++ b/lib/net/authorize/api/contract/v1/PayPalType.php
@@ -174,7 +174,11 @@ class PayPalType implements \JsonSerializable
     }
 
 
-    // Json Serialize Code
+    /**
+     * Json Serialize Code
+     *
+     * @return array|mixed
+     */
     public function jsonSerialize(){
         $values = array_filter((array)get_object_vars($this),
         function ($val){
@@ -208,8 +212,15 @@ class PayPalType implements \JsonSerializable
             return array_merge(parent::jsonSerialize(), $values);
         }
     }
-    
-    // Json Set Code
+
+    /**
+     * Json Set Code
+     *
+     * @param $data
+     * @throws \Exception
+     *
+     * @return void
+     */
     public function set($data)
     {
         if(is_array($data) || is_object($data)) {

--- a/lib/net/authorize/api/contract/v1/PaymentDetailsType.php
+++ b/lib/net/authorize/api/contract/v1/PaymentDetailsType.php
@@ -282,7 +282,11 @@ class PaymentDetailsType implements \JsonSerializable
     }
 
 
-    // Json Serialize Code
+    /**
+     * Json Serialize Code
+     *
+     * @return array|mixed
+     */
     public function jsonSerialize(){
         $values = array_filter((array)get_object_vars($this),
         function ($val){
@@ -316,8 +320,15 @@ class PaymentDetailsType implements \JsonSerializable
             return array_merge(parent::jsonSerialize(), $values);
         }
     }
-    
-    // Json Set Code
+
+    /**
+     * Json Set Code
+     *
+     * @param $data
+     * @throws \Exception
+     *
+     * @return void
+     */
     public function set($data)
     {
         if(is_array($data) || is_object($data)) {

--- a/lib/net/authorize/api/contract/v1/PaymentEmvType.php
+++ b/lib/net/authorize/api/contract/v1/PaymentEmvType.php
@@ -93,7 +93,11 @@ class PaymentEmvType implements \JsonSerializable
     }
 
 
-    // Json Serialize Code
+    /**
+     * Json Serialize Code
+     * 
+     * @return array|mixed
+     */
     public function jsonSerialize(){
         $values = array_filter((array)get_object_vars($this),
         function ($val){
@@ -126,9 +130,16 @@ class PaymentEmvType implements \JsonSerializable
         else{
             return array_merge(parent::jsonSerialize(), $values);
         }
-    }
-    
-    // Json Set Code
+    } 
+
+    /**
+     * Json Set Code
+     * 
+     * @param $data
+     * @throws \Exception
+     *
+     * @return void
+     */
     public function set($data)
     {
         if(is_array($data) || is_object($data)) {

--- a/lib/net/authorize/api/contract/v1/PaymentMaskedType.php
+++ b/lib/net/authorize/api/contract/v1/PaymentMaskedType.php
@@ -93,7 +93,11 @@ class PaymentMaskedType implements \JsonSerializable
     }
 
 
-    // Json Serialize Code
+    /**
+     * Json Serialize Code
+     * 
+     * @return array|mixed
+     */
     public function jsonSerialize(){
         $values = array_filter((array)get_object_vars($this),
         function ($val){
@@ -126,9 +130,16 @@ class PaymentMaskedType implements \JsonSerializable
         else{
             return array_merge(parent::jsonSerialize(), $values);
         }
-    }
-    
-    // Json Set Code
+    } 
+
+    /**
+     * Json Set Code
+     * 
+     * @param $data
+     * @throws \Exception
+     *
+     * @return void
+     */
     public function set($data)
     {
         if(is_array($data) || is_object($data)) {

--- a/lib/net/authorize/api/contract/v1/PaymentProfileType.php
+++ b/lib/net/authorize/api/contract/v1/PaymentProfileType.php
@@ -66,7 +66,11 @@ class PaymentProfileType implements \JsonSerializable
     }
 
 
-    // Json Serialize Code
+    /**
+     * Json Serialize Code
+     *
+     * @return array|mixed
+     */
     public function jsonSerialize(){
         $values = array_filter((array)get_object_vars($this),
         function ($val){
@@ -100,8 +104,15 @@ class PaymentProfileType implements \JsonSerializable
             return array_merge(parent::jsonSerialize(), $values);
         }
     }
-    
-    // Json Set Code
+
+    /**
+     * Json Set Code
+     *
+     * @param $data
+     * @throws \Exception
+     *
+     * @return void
+     */
     public function set($data)
     {
         if(is_array($data) || is_object($data)) {

--- a/lib/net/authorize/api/contract/v1/PaymentScheduleType.php
+++ b/lib/net/authorize/api/contract/v1/PaymentScheduleType.php
@@ -123,7 +123,11 @@ class PaymentScheduleType implements \JsonSerializable
     }
 
 
-    // Json Serialize Code
+    /**
+     * Json Serialize Code
+     * 
+     * @return array|mixed
+     */
     public function jsonSerialize(){
         $values = array_filter((array)get_object_vars($this),
         function ($val){
@@ -156,9 +160,16 @@ class PaymentScheduleType implements \JsonSerializable
         else{
             return array_merge(parent::jsonSerialize(), $values);
         }
-    }
-    
-    // Json Set Code
+    } 
+
+    /**
+     * Json Set Code
+     * 
+     * @param $data
+     * @throws \Exception
+     *
+     * @return void
+     */
     public function set($data)
     {
         if(is_array($data) || is_object($data)) {

--- a/lib/net/authorize/api/contract/v1/PaymentScheduleType/IntervalAType.php
+++ b/lib/net/authorize/api/contract/v1/PaymentScheduleType/IntervalAType.php
@@ -63,7 +63,11 @@ class IntervalAType implements \JsonSerializable
     }
 
 
-    // Json Serialize Code
+    /**
+     * Json Serialize Code
+     * 
+     * @return array|mixed
+     */
     public function jsonSerialize(){
         $values = array_filter((array)get_object_vars($this),
         function ($val){
@@ -96,9 +100,16 @@ class IntervalAType implements \JsonSerializable
         else{
             return array_merge(parent::jsonSerialize(), $values);
         }
-    }
-    
-    // Json Set Code
+    } 
+
+    /**
+     * Json Set Code
+     * 
+     * @param $data
+     * @throws \Exception
+     *
+     * @return void
+     */
     public function set($data)
     {
         if(is_array($data) || is_object($data)) {

--- a/lib/net/authorize/api/contract/v1/PaymentSimpleType.php
+++ b/lib/net/authorize/api/contract/v1/PaymentSimpleType.php
@@ -66,7 +66,11 @@ class PaymentSimpleType implements \JsonSerializable
     }
 
 
-    // Json Serialize Code
+    /**
+     * Json Serialize Code
+     *
+     * @return array|mixed
+     */
     public function jsonSerialize(){
         $values = array_filter((array)get_object_vars($this),
         function ($val){
@@ -100,8 +104,15 @@ class PaymentSimpleType implements \JsonSerializable
             return array_merge(parent::jsonSerialize(), $values);
         }
     }
-    
-    // Json Set Code
+
+    /**
+     * Json Set Code
+     *
+     * @param $data
+     * @throws \Exception
+     *
+     * @return void
+     */
     public function set($data)
     {
         if(is_array($data) || is_object($data)) {

--- a/lib/net/authorize/api/contract/v1/PaymentType.php
+++ b/lib/net/authorize/api/contract/v1/PaymentType.php
@@ -229,7 +229,11 @@ class PaymentType implements \JsonSerializable
     }
 
 
-    // Json Serialize Code
+    /**
+     * Json Serialize Code
+     * 
+     * @return array|mixed
+     */
     public function jsonSerialize(){
         $values = array_filter((array)get_object_vars($this),
         function ($val){
@@ -262,9 +266,16 @@ class PaymentType implements \JsonSerializable
         else{
             return array_merge(parent::jsonSerialize(), $values);
         }
-    }
-    
-    // Json Set Code
+    } 
+
+    /**
+     * Json Set Code
+     * 
+     * @param $data
+     * @throws \Exception
+     *
+     * @return void
+     */
     public function set($data)
     {
         if(is_array($data) || is_object($data)) {

--- a/lib/net/authorize/api/contract/v1/PermissionType.php
+++ b/lib/net/authorize/api/contract/v1/PermissionType.php
@@ -39,7 +39,11 @@ class PermissionType implements \JsonSerializable
     }
 
 
-    // Json Serialize Code
+    /**
+     * Json Serialize Code
+     * 
+     * @return array|mixed
+     */
     public function jsonSerialize(){
         $values = array_filter((array)get_object_vars($this),
         function ($val){
@@ -72,9 +76,16 @@ class PermissionType implements \JsonSerializable
         else{
             return array_merge(parent::jsonSerialize(), $values);
         }
-    }
-    
-    // Json Set Code
+    } 
+
+    /**
+     * Json Set Code
+     * 
+     * @param $data
+     * @throws \Exception
+     *
+     * @return void
+     */
     public function set($data)
     {
         if(is_array($data) || is_object($data)) {

--- a/lib/net/authorize/api/contract/v1/ProcessingOptionsType.php
+++ b/lib/net/authorize/api/contract/v1/ProcessingOptionsType.php
@@ -120,7 +120,11 @@ class ProcessingOptionsType implements \JsonSerializable
     }
 
 
-    // Json Serialize Code
+    /**
+     * Json Serialize Code
+     *
+     * @return array|mixed
+     */
     public function jsonSerialize(){
         $values = array_filter((array)get_object_vars($this),
         function ($val){
@@ -154,8 +158,15 @@ class ProcessingOptionsType implements \JsonSerializable
             return array_merge(parent::jsonSerialize(), $values);
         }
     }
-    
-    // Json Set Code
+
+    /**
+     * Json Set Code
+     *
+     * @param $data
+     * @throws \Exception
+     *
+     * @return void
+     */
     public function set($data)
     {
         if(is_array($data) || is_object($data)) {

--- a/lib/net/authorize/api/contract/v1/ProcessorType.php
+++ b/lib/net/authorize/api/contract/v1/ProcessorType.php
@@ -127,7 +127,11 @@ class ProcessorType implements \JsonSerializable
     }
 
 
-    // Json Serialize Code
+    /**
+     * Json Serialize Code
+     *
+     * @return array|mixed
+     */
     public function jsonSerialize(){
         $values = array_filter((array)get_object_vars($this),
         function ($val){
@@ -161,8 +165,15 @@ class ProcessorType implements \JsonSerializable
             return array_merge(parent::jsonSerialize(), $values);
         }
     }
-    
-    // Json Set Code
+
+    /**
+     * Json Set Code
+     *
+     * @param $data
+     * @throws \Exception
+     *
+     * @return void
+     */
     public function set($data)
     {
         if(is_array($data) || is_object($data)) {

--- a/lib/net/authorize/api/contract/v1/ProfileTransAmountType.php
+++ b/lib/net/authorize/api/contract/v1/ProfileTransAmountType.php
@@ -181,7 +181,11 @@ class ProfileTransAmountType implements \JsonSerializable
     }
 
 
-    // Json Serialize Code
+    /**
+     * Json Serialize Code
+     * 
+     * @return array|mixed
+     */
     public function jsonSerialize(){
         $values = array_filter((array)get_object_vars($this),
         function ($val){
@@ -214,9 +218,16 @@ class ProfileTransAmountType implements \JsonSerializable
         else{
             return array_merge(parent::jsonSerialize(), $values);
         }
-    }
-    
-    // Json Set Code
+    } 
+
+    /**
+     * Json Set Code
+     * 
+     * @param $data
+     * @throws \Exception
+     *
+     * @return void
+     */
     public function set($data)
     {
         if(is_array($data) || is_object($data)) {

--- a/lib/net/authorize/api/contract/v1/ProfileTransAuthCaptureType.php
+++ b/lib/net/authorize/api/contract/v1/ProfileTransAuthCaptureType.php
@@ -12,7 +12,11 @@ class ProfileTransAuthCaptureType extends ProfileTransOrderType implements \Json
 {
 
 
-    // Json Serialize Code
+    /**
+     * Json Serialize Code
+     * 
+     * @return array|mixed
+     */
     public function jsonSerialize(){
         $values = array_filter((array)get_object_vars($this),
         function ($val){
@@ -45,9 +49,16 @@ class ProfileTransAuthCaptureType extends ProfileTransOrderType implements \Json
         else{
             return array_merge(parent::jsonSerialize(), $values);
         }
-    }
-    
-    // Json Set Code
+    } 
+
+    /**
+     * Json Set Code
+     * 
+     * @param $data
+     * @throws \Exception
+     *
+     * @return void
+     */
     public function set($data)
     {
         if(is_array($data) || is_object($data)) {

--- a/lib/net/authorize/api/contract/v1/ProfileTransAuthOnlyType.php
+++ b/lib/net/authorize/api/contract/v1/ProfileTransAuthOnlyType.php
@@ -12,7 +12,11 @@ class ProfileTransAuthOnlyType extends ProfileTransOrderType implements \JsonSer
 {
 
 
-    // Json Serialize Code
+    /**
+     * Json Serialize Code
+     *
+     * @return array|mixed
+     */
     public function jsonSerialize(){
         $values = array_filter((array)get_object_vars($this),
         function ($val){
@@ -46,8 +50,15 @@ class ProfileTransAuthOnlyType extends ProfileTransOrderType implements \JsonSer
             return array_merge(parent::jsonSerialize(), $values);
         }
     }
-    
-    // Json Set Code
+
+    /**
+     * Json Set Code
+     *
+     * @param $data
+     * @throws \Exception
+     *
+     * @return void
+     */
     public function set($data)
     {
         if(is_array($data) || is_object($data)) {

--- a/lib/net/authorize/api/contract/v1/ProfileTransCaptureOnlyType.php
+++ b/lib/net/authorize/api/contract/v1/ProfileTransCaptureOnlyType.php
@@ -39,7 +39,11 @@ class ProfileTransCaptureOnlyType extends ProfileTransOrderType implements \Json
     }
 
 
-    // Json Serialize Code
+    /**
+     * Json Serialize Code
+     *
+     * @return array|mixed
+     */
     public function jsonSerialize(){
         $values = array_filter((array)get_object_vars($this),
         function ($val){
@@ -73,8 +77,15 @@ class ProfileTransCaptureOnlyType extends ProfileTransOrderType implements \Json
             return array_merge(parent::jsonSerialize(), $values);
         }
     }
-    
-    // Json Set Code
+
+    /**
+     * Json Set Code
+     *
+     * @param $data
+     * @throws \Exception
+     *
+     * @return void
+     */
     public function set($data)
     {
         if(is_array($data) || is_object($data)) {

--- a/lib/net/authorize/api/contract/v1/ProfileTransOrderType.php
+++ b/lib/net/authorize/api/contract/v1/ProfileTransOrderType.php
@@ -285,7 +285,11 @@ class ProfileTransOrderType extends ProfileTransAmountType implements \JsonSeria
     }
 
 
-    // Json Serialize Code
+    /**
+     * Json Serialize Code
+     * 
+     * @return array|mixed
+     */
     public function jsonSerialize(){
         $values = array_filter((array)get_object_vars($this),
         function ($val){
@@ -318,9 +322,16 @@ class ProfileTransOrderType extends ProfileTransAmountType implements \JsonSeria
         else{
             return array_merge(parent::jsonSerialize(), $values);
         }
-    }
-    
-    // Json Set Code
+    } 
+
+    /**
+     * Json Set Code
+     * 
+     * @param $data
+     * @throws \Exception
+     *
+     * @return void
+     */
     public function set($data)
     {
         if(is_array($data) || is_object($data)) {

--- a/lib/net/authorize/api/contract/v1/ProfileTransPriorAuthCaptureType.php
+++ b/lib/net/authorize/api/contract/v1/ProfileTransPriorAuthCaptureType.php
@@ -120,7 +120,11 @@ class ProfileTransPriorAuthCaptureType extends ProfileTransAmountType implements
     }
 
 
-    // Json Serialize Code
+    /**
+     * Json Serialize Code
+     *
+     * @return array|mixed
+     */
     public function jsonSerialize(){
         $values = array_filter((array)get_object_vars($this),
         function ($val){
@@ -154,8 +158,15 @@ class ProfileTransPriorAuthCaptureType extends ProfileTransAmountType implements
             return array_merge(parent::jsonSerialize(), $values);
         }
     }
-    
-    // Json Set Code
+
+    /**
+     * Json Set Code
+     *
+     * @param $data
+     * @throws \Exception
+     *
+     * @return void
+     */
     public function set($data)
     {
         if(is_array($data) || is_object($data)) {

--- a/lib/net/authorize/api/contract/v1/ProfileTransRefundType.php
+++ b/lib/net/authorize/api/contract/v1/ProfileTransRefundType.php
@@ -228,7 +228,11 @@ class ProfileTransRefundType extends ProfileTransAmountType implements \JsonSeri
     }
 
 
-    // Json Serialize Code
+    /**
+     * Json Serialize Code
+     * 
+     * @return array|mixed
+     */
     public function jsonSerialize(){
         $values = array_filter((array)get_object_vars($this),
         function ($val){
@@ -261,9 +265,16 @@ class ProfileTransRefundType extends ProfileTransAmountType implements \JsonSeri
         else{
             return array_merge(parent::jsonSerialize(), $values);
         }
-    }
-    
-    // Json Set Code
+    } 
+
+    /**
+     * Json Set Code
+     * 
+     * @param $data
+     * @throws \Exception
+     *
+     * @return void
+     */
     public function set($data)
     {
         if(is_array($data) || is_object($data)) {

--- a/lib/net/authorize/api/contract/v1/ProfileTransVoidType.php
+++ b/lib/net/authorize/api/contract/v1/ProfileTransVoidType.php
@@ -120,7 +120,11 @@ class ProfileTransVoidType implements \JsonSerializable
     }
 
 
-    // Json Serialize Code
+    /**
+     * Json Serialize Code
+     * 
+     * @return array|mixed
+     */
     public function jsonSerialize(){
         $values = array_filter((array)get_object_vars($this),
         function ($val){
@@ -153,9 +157,16 @@ class ProfileTransVoidType implements \JsonSerializable
         else{
             return array_merge(parent::jsonSerialize(), $values);
         }
-    }
-    
-    // Json Set Code
+    } 
+
+    /**
+     * Json Set Code
+     * 
+     * @param $data
+     * @throws \Exception
+     *
+     * @return void
+     */
     public function set($data)
     {
         if(is_array($data) || is_object($data)) {

--- a/lib/net/authorize/api/contract/v1/ProfileTransactionType.php
+++ b/lib/net/authorize/api/contract/v1/ProfileTransactionType.php
@@ -183,7 +183,11 @@ class ProfileTransactionType implements \JsonSerializable
     }
 
 
-    // Json Serialize Code
+    /**
+     * Json Serialize Code
+     *
+     * @return array|mixed
+     */
     public function jsonSerialize(){
         $values = array_filter((array)get_object_vars($this),
         function ($val){
@@ -217,8 +221,15 @@ class ProfileTransactionType implements \JsonSerializable
             return array_merge(parent::jsonSerialize(), $values);
         }
     }
-    
-    // Json Set Code
+
+    /**
+     * Json Set Code
+     *
+     * @param $data
+     * @throws \Exception
+     *
+     * @return void
+     */
     public function set($data)
     {
         if(is_array($data) || is_object($data)) {

--- a/lib/net/authorize/api/contract/v1/ReturnedItemType.php
+++ b/lib/net/authorize/api/contract/v1/ReturnedItemType.php
@@ -147,7 +147,11 @@ class ReturnedItemType implements \JsonSerializable
     }
 
 
-    // Json Serialize Code
+    /**
+     * Json Serialize Code
+     * 
+     * @return array|mixed
+     */
     public function jsonSerialize(){
         $values = array_filter((array)get_object_vars($this),
         function ($val){
@@ -180,9 +184,16 @@ class ReturnedItemType implements \JsonSerializable
         else{
             return array_merge(parent::jsonSerialize(), $values);
         }
-    }
-    
-    // Json Set Code
+    } 
+
+    /**
+     * Json Set Code
+     * 
+     * @param $data
+     * @throws \Exception
+     *
+     * @return void
+     */
     public function set($data)
     {
         if(is_array($data) || is_object($data)) {

--- a/lib/net/authorize/api/contract/v1/SecurePaymentContainerErrorType.php
+++ b/lib/net/authorize/api/contract/v1/SecurePaymentContainerErrorType.php
@@ -66,7 +66,11 @@ class SecurePaymentContainerErrorType implements \JsonSerializable
     }
 
 
-    // Json Serialize Code
+    /**
+     * Json Serialize Code
+     * 
+     * @return array|mixed
+     */
     public function jsonSerialize(){
         $values = array_filter((array)get_object_vars($this),
         function ($val){
@@ -99,9 +103,16 @@ class SecurePaymentContainerErrorType implements \JsonSerializable
         else{
             return array_merge(parent::jsonSerialize(), $values);
         }
-    }
-    
-    // Json Set Code
+    } 
+
+    /**
+     * Json Set Code
+     * 
+     * @param $data
+     * @throws \Exception
+     *
+     * @return void
+     */
     public function set($data)
     {
         if(is_array($data) || is_object($data)) {

--- a/lib/net/authorize/api/contract/v1/SecurePaymentContainerRequest.php
+++ b/lib/net/authorize/api/contract/v1/SecurePaymentContainerRequest.php
@@ -36,7 +36,11 @@ class SecurePaymentContainerRequest extends ANetApiRequestType
     }
 
 
-    // Json Serialize Code
+    /**
+     * Json Serialize Code
+     * 
+     * @return array|mixed
+     */
     public function jsonSerialize(){
         $values = array_filter((array)get_object_vars($this),
         function ($val){

--- a/lib/net/authorize/api/contract/v1/SecurePaymentContainerResponse.php
+++ b/lib/net/authorize/api/contract/v1/SecurePaymentContainerResponse.php
@@ -35,8 +35,14 @@ class SecurePaymentContainerResponse extends ANetApiResponseType
         return $this;
     }
 
-
-    // Json Set Code
+    /**
+     * Json Set Code
+     *
+     * @param $data
+     * @throws \Exception
+     *
+     * @return void
+     */
     public function set($data)
     {
         if(is_array($data) || is_object($data)) {

--- a/lib/net/authorize/api/contract/v1/SendCustomerTransactionReceiptRequest.php
+++ b/lib/net/authorize/api/contract/v1/SendCustomerTransactionReceiptRequest.php
@@ -90,7 +90,11 @@ class SendCustomerTransactionReceiptRequest extends ANetApiRequestType
     }
 
 
-    // Json Serialize Code
+    /**
+     * Json Serialize Code
+     * 
+     * @return array|mixed
+     */
     public function jsonSerialize(){
         $values = array_filter((array)get_object_vars($this),
         function ($val){

--- a/lib/net/authorize/api/contract/v1/SendCustomerTransactionReceiptResponse.php
+++ b/lib/net/authorize/api/contract/v1/SendCustomerTransactionReceiptResponse.php
@@ -8,8 +8,14 @@ namespace net\authorize\api\contract\v1;
 class SendCustomerTransactionReceiptResponse extends ANetApiResponseType
 {
 
-
-    // Json Set Code
+    /**
+     * Json Set Code
+     *
+     * @param $data
+     * @throws \Exception
+     *
+     * @return void
+     */
     public function set($data)
     {
         if(is_array($data) || is_object($data)) {

--- a/lib/net/authorize/api/contract/v1/SettingType.php
+++ b/lib/net/authorize/api/contract/v1/SettingType.php
@@ -66,7 +66,11 @@ class SettingType implements \JsonSerializable
     }
 
 
-    // Json Serialize Code
+    /**
+     * Json Serialize Code
+     *
+     * @return array|mixed
+     */
     public function jsonSerialize(){
         $values = array_filter((array)get_object_vars($this),
         function ($val){
@@ -100,8 +104,15 @@ class SettingType implements \JsonSerializable
             return array_merge(parent::jsonSerialize(), $values);
         }
     }
-    
-    // Json Set Code
+
+    /**
+     * Json Set Code
+     *
+     * @param $data
+     * @throws \Exception
+     *
+     * @return void
+     */
     public function set($data)
     {
         if(is_array($data) || is_object($data)) {

--- a/lib/net/authorize/api/contract/v1/SolutionType.php
+++ b/lib/net/authorize/api/contract/v1/SolutionType.php
@@ -93,7 +93,11 @@ class SolutionType implements \JsonSerializable
     }
 
 
-    // Json Serialize Code
+    /**
+     * Json Serialize Code
+     * 
+     * @return array|mixed
+     */
     public function jsonSerialize(){
         $values = array_filter((array)get_object_vars($this),
         function ($val){
@@ -126,9 +130,16 @@ class SolutionType implements \JsonSerializable
         else{
             return array_merge(parent::jsonSerialize(), $values);
         }
-    }
-    
-    // Json Set Code
+    } 
+
+    /**
+     * Json Set Code
+     * 
+     * @param $data
+     * @throws \Exception
+     *
+     * @return void
+     */
     public function set($data)
     {
         if(is_array($data) || is_object($data)) {

--- a/lib/net/authorize/api/contract/v1/SubMerchantType.php
+++ b/lib/net/authorize/api/contract/v1/SubMerchantType.php
@@ -309,7 +309,11 @@ class SubMerchantType implements \JsonSerializable
     }
 
 
-    // Json Serialize Code
+    /**
+     * Json Serialize Code
+     *
+     * @return array|mixed
+     */
     public function jsonSerialize(){
         $values = array_filter((array)get_object_vars($this),
         function ($val){
@@ -343,8 +347,15 @@ class SubMerchantType implements \JsonSerializable
             return array_merge(parent::jsonSerialize(), $values);
         }
     }
-    
-    // Json Set Code
+
+    /**
+     * Json Set Code
+     *
+     * @param $data
+     * @throws \Exception
+     *
+     * @return void
+     */
     public function set($data)
     {
         if(is_array($data) || is_object($data)) {

--- a/lib/net/authorize/api/contract/v1/SubscriptionCustomerProfileType.php
+++ b/lib/net/authorize/api/contract/v1/SubscriptionCustomerProfileType.php
@@ -68,7 +68,11 @@ class SubscriptionCustomerProfileType extends CustomerProfileExType implements \
     }
 
 
-    // Json Serialize Code
+    /**
+     * Json Serialize Code
+     * 
+     * @return array|mixed
+     */
     public function jsonSerialize(){
         $values = array_filter((array)get_object_vars($this),
         function ($val){
@@ -101,9 +105,16 @@ class SubscriptionCustomerProfileType extends CustomerProfileExType implements \
         else{
             return array_merge(parent::jsonSerialize(), $values);
         }
-    }
-    
-    // Json Set Code
+    } 
+
+    /**
+     * Json Set Code
+     * 
+     * @param $data
+     * @throws \Exception
+     *
+     * @return void
+     */
     public function set($data)
     {
         if(is_array($data) || is_object($data)) {

--- a/lib/net/authorize/api/contract/v1/SubscriptionDetailType.php
+++ b/lib/net/authorize/api/contract/v1/SubscriptionDetailType.php
@@ -444,7 +444,11 @@ class SubscriptionDetailType implements \JsonSerializable
     }
 
 
-    // Json Serialize Code
+    /**
+     * Json Serialize Code
+     * 
+     * @return array|mixed
+     */
     public function jsonSerialize(){
         $values = array_filter((array)get_object_vars($this),
         function ($val){
@@ -477,9 +481,16 @@ class SubscriptionDetailType implements \JsonSerializable
         else{
             return array_merge(parent::jsonSerialize(), $values);
         }
-    }
-    
-    // Json Set Code
+    } 
+
+    /**
+     * Json Set Code
+     * 
+     * @param $data
+     * @throws \Exception
+     *
+     * @return void
+     */
     public function set($data)
     {
         if(is_array($data) || is_object($data)) {

--- a/lib/net/authorize/api/contract/v1/SubscriptionPaymentType.php
+++ b/lib/net/authorize/api/contract/v1/SubscriptionPaymentType.php
@@ -66,7 +66,11 @@ class SubscriptionPaymentType implements \JsonSerializable
     }
 
 
-    // Json Serialize Code
+    /**
+     * Json Serialize Code
+     * 
+     * @return array|mixed
+     */
     public function jsonSerialize(){
         $values = array_filter((array)get_object_vars($this),
         function ($val){
@@ -99,9 +103,16 @@ class SubscriptionPaymentType implements \JsonSerializable
         else{
             return array_merge(parent::jsonSerialize(), $values);
         }
-    }
-    
-    // Json Set Code
+    } 
+
+    /**
+     * Json Set Code
+     * 
+     * @param $data
+     * @throws \Exception
+     *
+     * @return void
+     */
     public function set($data)
     {
         if(is_array($data) || is_object($data)) {

--- a/lib/net/authorize/api/contract/v1/SubsequentAuthInformationType.php
+++ b/lib/net/authorize/api/contract/v1/SubsequentAuthInformationType.php
@@ -66,7 +66,11 @@ class SubsequentAuthInformationType implements \JsonSerializable
     }
 
 
-    // Json Serialize Code
+    /**
+     * Json Serialize Code
+     * 
+     * @return array|mixed
+     */
     public function jsonSerialize(){
         $values = array_filter((array)get_object_vars($this),
         function ($val){
@@ -99,9 +103,16 @@ class SubsequentAuthInformationType implements \JsonSerializable
         else{
             return array_merge(parent::jsonSerialize(), $values);
         }
-    }
-    
-    // Json Set Code
+    } 
+
+    /**
+     * Json Set Code
+     * 
+     * @param $data
+     * @throws \Exception
+     *
+     * @return void
+     */
     public function set($data)
     {
         if(is_array($data) || is_object($data)) {

--- a/lib/net/authorize/api/contract/v1/TokenMaskedType.php
+++ b/lib/net/authorize/api/contract/v1/TokenMaskedType.php
@@ -120,7 +120,11 @@ class TokenMaskedType implements \JsonSerializable
     }
 
 
-    // Json Serialize Code
+    /**
+     * Json Serialize Code
+     *
+     * @return array|mixed
+     */
     public function jsonSerialize(){
         $values = array_filter((array)get_object_vars($this),
         function ($val){
@@ -154,8 +158,15 @@ class TokenMaskedType implements \JsonSerializable
             return array_merge(parent::jsonSerialize(), $values);
         }
     }
-    
-    // Json Set Code
+
+    /**
+     * Json Set Code
+     *
+     * @param $data
+     * @throws \Exception
+     *
+     * @return void
+     */
     public function set($data)
     {
         if(is_array($data) || is_object($data)) {

--- a/lib/net/authorize/api/contract/v1/TransRetailInfoType.php
+++ b/lib/net/authorize/api/contract/v1/TransRetailInfoType.php
@@ -120,7 +120,11 @@ class TransRetailInfoType implements \JsonSerializable
     }
 
 
-    // Json Serialize Code
+    /**
+     * Json Serialize Code
+     * 
+     * @return array|mixed
+     */
     public function jsonSerialize(){
         $values = array_filter((array)get_object_vars($this),
         function ($val){
@@ -153,9 +157,16 @@ class TransRetailInfoType implements \JsonSerializable
         else{
             return array_merge(parent::jsonSerialize(), $values);
         }
-    }
-    
-    // Json Set Code
+    } 
+
+    /**
+     * Json Set Code
+     * 
+     * @param $data
+     * @throws \Exception
+     *
+     * @return void
+     */
     public function set($data)
     {
         if(is_array($data) || is_object($data)) {

--- a/lib/net/authorize/api/contract/v1/TransactionDetailsType.php
+++ b/lib/net/authorize/api/contract/v1/TransactionDetailsType.php
@@ -1451,7 +1451,11 @@ class TransactionDetailsType implements \JsonSerializable
     }
 
 
-    // Json Serialize Code
+    /**
+     * Json Serialize Code
+     * 
+     * @return array|mixed
+     */
     public function jsonSerialize(){
         $values = array_filter((array)get_object_vars($this),
         function ($val){
@@ -1484,9 +1488,16 @@ class TransactionDetailsType implements \JsonSerializable
         else{
             return array_merge(parent::jsonSerialize(), $values);
         }
-    }
-    
-    // Json Set Code
+    } 
+
+    /**
+     * Json Set Code
+     * 
+     * @param $data
+     * @throws \Exception
+     *
+     * @return void
+     */
     public function set($data)
     {
         if(is_array($data) || is_object($data)) {

--- a/lib/net/authorize/api/contract/v1/TransactionDetailsType/EmvDetailsAType.php
+++ b/lib/net/authorize/api/contract/v1/TransactionDetailsType/EmvDetailsAType.php
@@ -77,7 +77,11 @@ class EmvDetailsAType implements \JsonSerializable
     }
 
 
-    // Json Serialize Code
+    /**
+     * Json Serialize Code
+     * 
+     * @return array|mixed
+     */
     public function jsonSerialize(){
         $values = array_filter((array)get_object_vars($this),
         function ($val){
@@ -110,9 +114,16 @@ class EmvDetailsAType implements \JsonSerializable
         else{
             return array_merge(parent::jsonSerialize(), $values);
         }
-    }
-    
-    // Json Set Code
+    } 
+
+    /**
+     * Json Set Code
+     * 
+     * @param $data
+     * @throws \Exception
+     *
+     * @return void
+     */
     public function set($data)
     {
         if(is_array($data) || is_object($data)) {

--- a/lib/net/authorize/api/contract/v1/TransactionDetailsType/EmvDetailsAType/TagAType.php
+++ b/lib/net/authorize/api/contract/v1/TransactionDetailsType/EmvDetailsAType/TagAType.php
@@ -63,7 +63,11 @@ class TagAType implements \JsonSerializable
     }
 
 
-    // Json Serialize Code
+    /**
+     * Json Serialize Code
+     * 
+     * @return array|mixed
+     */
     public function jsonSerialize(){
         $values = array_filter((array)get_object_vars($this),
         function ($val){
@@ -96,9 +100,16 @@ class TagAType implements \JsonSerializable
         else{
             return array_merge(parent::jsonSerialize(), $values);
         }
-    }
-    
-    // Json Set Code
+    } 
+
+    /**
+     * Json Set Code
+     * 
+     * @param $data
+     * @throws \Exception
+     *
+     * @return void
+     */
     public function set($data)
     {
         if(is_array($data) || is_object($data)) {

--- a/lib/net/authorize/api/contract/v1/TransactionListSortingType.php
+++ b/lib/net/authorize/api/contract/v1/TransactionListSortingType.php
@@ -66,7 +66,11 @@ class TransactionListSortingType implements \JsonSerializable
     }
 
 
-    // Json Serialize Code
+    /**
+     * Json Serialize Code
+     * 
+     * @return array|mixed
+     */
     public function jsonSerialize(){
         $values = array_filter((array)get_object_vars($this),
         function ($val){
@@ -99,9 +103,16 @@ class TransactionListSortingType implements \JsonSerializable
         else{
             return array_merge(parent::jsonSerialize(), $values);
         }
-    }
-    
-    // Json Set Code
+    } 
+
+    /**
+     * Json Set Code
+     * 
+     * @param $data
+     * @throws \Exception
+     *
+     * @return void
+     */
     public function set($data)
     {
         if(is_array($data) || is_object($data)) {

--- a/lib/net/authorize/api/contract/v1/TransactionRequestType.php
+++ b/lib/net/authorize/api/contract/v1/TransactionRequestType.php
@@ -1088,7 +1088,11 @@ class TransactionRequestType implements \JsonSerializable
     }
 
 
-    // Json Serialize Code
+    /**
+     * Json Serialize Code
+     *
+     * @return array|mixed
+     */
     public function jsonSerialize(){
         $values = array_filter((array)get_object_vars($this),
         function ($val){
@@ -1122,8 +1126,15 @@ class TransactionRequestType implements \JsonSerializable
             return array_merge(parent::jsonSerialize(), $values);
         }
     }
-    
-    // Json Set Code
+
+    /**
+     * Json Set Code
+     *
+     * @param $data
+     * @throws \Exception
+     *
+     * @return void
+     */
     public function set($data)
     {
         if(is_array($data) || is_object($data)) {

--- a/lib/net/authorize/api/contract/v1/TransactionRequestType/UserFieldsAType.php
+++ b/lib/net/authorize/api/contract/v1/TransactionRequestType/UserFieldsAType.php
@@ -70,7 +70,11 @@ class UserFieldsAType implements \JsonSerializable
     }
 
 
-    // Json Serialize Code
+    /**
+     * Json Serialize Code
+     *
+     * @return array|mixed
+     */
     public function jsonSerialize(){
         $values = array_filter((array)get_object_vars($this),
         function ($val){
@@ -104,8 +108,15 @@ class UserFieldsAType implements \JsonSerializable
             return array_merge(parent::jsonSerialize(), $values);
         }
     }
-    
-    // Json Set Code
+
+    /**
+     * Json Set Code
+     *
+     * @param $data
+     * @throws \Exception
+     *
+     * @return void
+     */
     public function set($data)
     {
         if(is_array($data) || is_object($data)) {

--- a/lib/net/authorize/api/contract/v1/TransactionResponseType.php
+++ b/lib/net/authorize/api/contract/v1/TransactionResponseType.php
@@ -855,7 +855,11 @@ class TransactionResponseType implements \JsonSerializable
     }
 
 
-    // Json Serialize Code
+    /**
+     * Json Serialize Code
+     * 
+     * @return array|mixed
+     */
     public function jsonSerialize(){
         $values = array_filter((array)get_object_vars($this),
         function ($val){
@@ -888,9 +892,16 @@ class TransactionResponseType implements \JsonSerializable
         else{
             return array_merge(parent::jsonSerialize(), $values);
         }
-    }
-    
-    // Json Set Code
+    } 
+
+    /**
+     * Json Set Code
+     * 
+     * @param $data
+     * @throws \Exception
+     *
+     * @return void
+     */
     public function set($data)
     {
         if(is_array($data) || is_object($data)) {

--- a/lib/net/authorize/api/contract/v1/TransactionResponseType/EmvResponseAType.php
+++ b/lib/net/authorize/api/contract/v1/TransactionResponseType/EmvResponseAType.php
@@ -97,7 +97,11 @@ class EmvResponseAType implements \JsonSerializable
     }
 
 
-    // Json Serialize Code
+    /**
+     * Json Serialize Code
+     *
+     * @return array|mixed
+     */
     public function jsonSerialize(){
         $values = array_filter((array)get_object_vars($this),
         function ($val){
@@ -131,8 +135,15 @@ class EmvResponseAType implements \JsonSerializable
             return array_merge(parent::jsonSerialize(), $values);
         }
     }
-    
-    // Json Set Code
+
+    /**
+     * Json Set Code
+     *
+     * @param $data
+     * @throws \Exception
+     *
+     * @return void
+     */
     public function set($data)
     {
         if(is_array($data) || is_object($data)) {

--- a/lib/net/authorize/api/contract/v1/TransactionResponseType/EmvResponseAType/TagsAType.php
+++ b/lib/net/authorize/api/contract/v1/TransactionResponseType/EmvResponseAType/TagsAType.php
@@ -70,7 +70,11 @@ class TagsAType implements \JsonSerializable
     }
 
 
-    // Json Serialize Code
+    /**
+     * Json Serialize Code
+     *
+     * @return array|mixed
+     */
     public function jsonSerialize(){
         $values = array_filter((array)get_object_vars($this),
         function ($val){
@@ -104,8 +108,15 @@ class TagsAType implements \JsonSerializable
             return array_merge(parent::jsonSerialize(), $values);
         }
     }
-    
-    // Json Set Code
+
+    /**
+     * Json Set Code
+     *
+     * @param $data
+     * @throws \Exception
+     *
+     * @return void
+     */
     public function set($data)
     {
         if(is_array($data) || is_object($data)) {

--- a/lib/net/authorize/api/contract/v1/TransactionResponseType/ErrorsAType.php
+++ b/lib/net/authorize/api/contract/v1/TransactionResponseType/ErrorsAType.php
@@ -77,7 +77,11 @@ class ErrorsAType implements \JsonSerializable
     }
 
 
-    // Json Serialize Code
+    /**
+     * Json Serialize Code
+     * 
+     * @return array|mixed
+     */
     public function jsonSerialize(){
         $values = array_filter((array)get_object_vars($this),
         function ($val){
@@ -110,9 +114,16 @@ class ErrorsAType implements \JsonSerializable
         else{
             return array_merge(parent::jsonSerialize(), $values);
         }
-    }
-    
-    // Json Set Code
+    } 
+
+    /**
+     * Json Set Code
+     * 
+     * @param $data
+     * @throws \Exception
+     *
+     * @return void
+     */
     public function set($data)
     {
         if(is_array($data) || is_object($data)) {

--- a/lib/net/authorize/api/contract/v1/TransactionResponseType/ErrorsAType/ErrorAType.php
+++ b/lib/net/authorize/api/contract/v1/TransactionResponseType/ErrorsAType/ErrorAType.php
@@ -63,7 +63,11 @@ class ErrorAType implements \JsonSerializable
     }
 
 
-    // Json Serialize Code
+    /**
+     * Json Serialize Code
+     * 
+     * @return array|mixed
+     */
     public function jsonSerialize(){
         $values = array_filter((array)get_object_vars($this),
         function ($val){
@@ -96,9 +100,16 @@ class ErrorAType implements \JsonSerializable
         else{
             return array_merge(parent::jsonSerialize(), $values);
         }
-    }
-    
-    // Json Set Code
+    } 
+
+    /**
+     * Json Set Code
+     * 
+     * @param $data
+     * @throws \Exception
+     *
+     * @return void
+     */
     public function set($data)
     {
         if(is_array($data) || is_object($data)) {

--- a/lib/net/authorize/api/contract/v1/TransactionResponseType/MessagesAType.php
+++ b/lib/net/authorize/api/contract/v1/TransactionResponseType/MessagesAType.php
@@ -77,7 +77,11 @@ class MessagesAType implements \JsonSerializable
     }
 
 
-    // Json Serialize Code
+    /**
+     * Json Serialize Code
+     * 
+     * @return array|mixed
+     */
     public function jsonSerialize(){
         $values = array_filter((array)get_object_vars($this),
         function ($val){
@@ -110,9 +114,16 @@ class MessagesAType implements \JsonSerializable
         else{
             return array_merge(parent::jsonSerialize(), $values);
         }
-    }
-    
-    // Json Set Code
+    } 
+
+    /**
+     * Json Set Code
+     * 
+     * @param $data
+     * @throws \Exception
+     *
+     * @return void
+     */
     public function set($data)
     {
         if(is_array($data) || is_object($data)) {

--- a/lib/net/authorize/api/contract/v1/TransactionResponseType/MessagesAType/MessageAType.php
+++ b/lib/net/authorize/api/contract/v1/TransactionResponseType/MessagesAType/MessageAType.php
@@ -63,7 +63,11 @@ class MessageAType implements \JsonSerializable
     }
 
 
-    // Json Serialize Code
+    /**
+     * Json Serialize Code
+     * 
+     * @return array|mixed
+     */
     public function jsonSerialize(){
         $values = array_filter((array)get_object_vars($this),
         function ($val){
@@ -96,9 +100,16 @@ class MessageAType implements \JsonSerializable
         else{
             return array_merge(parent::jsonSerialize(), $values);
         }
-    }
-    
-    // Json Set Code
+    } 
+
+    /**
+     * Json Set Code
+     * 
+     * @param $data
+     * @throws \Exception
+     *
+     * @return void
+     */
     public function set($data)
     {
         if(is_array($data) || is_object($data)) {

--- a/lib/net/authorize/api/contract/v1/TransactionResponseType/PrePaidCardAType.php
+++ b/lib/net/authorize/api/contract/v1/TransactionResponseType/PrePaidCardAType.php
@@ -90,7 +90,11 @@ class PrePaidCardAType implements \JsonSerializable
     }
 
 
-    // Json Serialize Code
+    /**
+     * Json Serialize Code
+     *
+     * @return array|mixed
+     */
     public function jsonSerialize(){
         $values = array_filter((array)get_object_vars($this),
         function ($val){
@@ -124,8 +128,15 @@ class PrePaidCardAType implements \JsonSerializable
             return array_merge(parent::jsonSerialize(), $values);
         }
     }
-    
-    // Json Set Code
+
+    /**
+     * Json Set Code
+     *
+     * @param $data
+     * @throws \Exception
+     *
+     * @return void
+     */
     public function set($data)
     {
         if(is_array($data) || is_object($data)) {

--- a/lib/net/authorize/api/contract/v1/TransactionResponseType/SecureAcceptanceAType.php
+++ b/lib/net/authorize/api/contract/v1/TransactionResponseType/SecureAcceptanceAType.php
@@ -90,7 +90,11 @@ class SecureAcceptanceAType implements \JsonSerializable
     }
 
 
-    // Json Serialize Code
+    /**
+     * Json Serialize Code
+     * 
+     * @return array|mixed
+     */
     public function jsonSerialize(){
         $values = array_filter((array)get_object_vars($this),
         function ($val){
@@ -123,9 +127,16 @@ class SecureAcceptanceAType implements \JsonSerializable
         else{
             return array_merge(parent::jsonSerialize(), $values);
         }
-    }
-    
-    // Json Set Code
+    } 
+
+    /**
+     * Json Set Code
+     * 
+     * @param $data
+     * @throws \Exception
+     *
+     * @return void
+     */
     public function set($data)
     {
         if(is_array($data) || is_object($data)) {

--- a/lib/net/authorize/api/contract/v1/TransactionResponseType/SplitTenderPaymentsAType.php
+++ b/lib/net/authorize/api/contract/v1/TransactionResponseType/SplitTenderPaymentsAType.php
@@ -77,7 +77,11 @@ class SplitTenderPaymentsAType implements \JsonSerializable
     }
 
 
-    // Json Serialize Code
+    /**
+     * Json Serialize Code
+     *
+     * @return array|mixed
+     */
     public function jsonSerialize(){
         $values = array_filter((array)get_object_vars($this),
         function ($val){
@@ -111,8 +115,15 @@ class SplitTenderPaymentsAType implements \JsonSerializable
             return array_merge(parent::jsonSerialize(), $values);
         }
     }
-    
-    // Json Set Code
+
+    /**
+     * Json Set Code
+     *
+     * @param $data
+     * @throws \Exception
+     *
+     * @return void
+     */
     public function set($data)
     {
         if(is_array($data) || is_object($data)) {

--- a/lib/net/authorize/api/contract/v1/TransactionResponseType/SplitTenderPaymentsAType/SplitTenderPaymentAType.php
+++ b/lib/net/authorize/api/contract/v1/TransactionResponseType/SplitTenderPaymentsAType/SplitTenderPaymentAType.php
@@ -252,7 +252,11 @@ class SplitTenderPaymentAType implements \JsonSerializable
     }
 
 
-    // Json Serialize Code
+    /**
+     * Json Serialize Code
+     * 
+     * @return array|mixed
+     */
     public function jsonSerialize(){
         $values = array_filter((array)get_object_vars($this),
         function ($val){
@@ -285,9 +289,16 @@ class SplitTenderPaymentAType implements \JsonSerializable
         else{
             return array_merge(parent::jsonSerialize(), $values);
         }
-    }
-    
-    // Json Set Code
+    } 
+
+    /**
+     * Json Set Code
+     * 
+     * @param $data
+     * @throws \Exception
+     *
+     * @return void
+     */
     public function set($data)
     {
         if(is_array($data) || is_object($data)) {

--- a/lib/net/authorize/api/contract/v1/TransactionResponseType/UserFieldsAType.php
+++ b/lib/net/authorize/api/contract/v1/TransactionResponseType/UserFieldsAType.php
@@ -70,7 +70,11 @@ class UserFieldsAType implements \JsonSerializable
     }
 
 
-    // Json Serialize Code
+    /**
+     * Json Serialize Code
+     * 
+     * @return array|mixed
+     */
     public function jsonSerialize(){
         $values = array_filter((array)get_object_vars($this),
         function ($val){
@@ -103,9 +107,16 @@ class UserFieldsAType implements \JsonSerializable
         else{
             return array_merge(parent::jsonSerialize(), $values);
         }
-    }
-    
-    // Json Set Code
+    } 
+
+    /**
+     * Json Set Code
+     * 
+     * @param $data
+     * @throws \Exception
+     *
+     * @return void
+     */
     public function set($data)
     {
         if(is_array($data) || is_object($data)) {

--- a/lib/net/authorize/api/contract/v1/TransactionSummaryType.php
+++ b/lib/net/authorize/api/contract/v1/TransactionSummaryType.php
@@ -471,7 +471,11 @@ class TransactionSummaryType implements \JsonSerializable
     }
 
 
-    // Json Serialize Code
+    /**
+     * Json Serialize Code
+     * 
+     * @return array|mixed
+     */
     public function jsonSerialize(){
         $values = array_filter((array)get_object_vars($this),
         function ($val){
@@ -504,9 +508,16 @@ class TransactionSummaryType implements \JsonSerializable
         else{
             return array_merge(parent::jsonSerialize(), $values);
         }
-    }
-    
-    // Json Set Code
+    } 
+
+    /**
+     * Json Set Code
+     * 
+     * @param $data
+     * @throws \Exception
+     *
+     * @return void
+     */
     public function set($data)
     {
         if(is_array($data) || is_object($data)) {

--- a/lib/net/authorize/api/contract/v1/UpdateCustomerPaymentProfileRequest.php
+++ b/lib/net/authorize/api/contract/v1/UpdateCustomerPaymentProfileRequest.php
@@ -92,7 +92,11 @@ class UpdateCustomerPaymentProfileRequest extends ANetApiRequestType
     }
 
 
-    // Json Serialize Code
+    /**
+     * Json Serialize Code
+     * 
+     * @return array|mixed
+     */
     public function jsonSerialize(){
         $values = array_filter((array)get_object_vars($this),
         function ($val){

--- a/lib/net/authorize/api/contract/v1/UpdateCustomerPaymentProfileResponse.php
+++ b/lib/net/authorize/api/contract/v1/UpdateCustomerPaymentProfileResponse.php
@@ -33,10 +33,16 @@ class UpdateCustomerPaymentProfileResponse extends ANetApiResponseType
     {
         $this->validationDirectResponse = $validationDirectResponse;
         return $this;
-    }
+    } 
 
-
-    // Json Set Code
+    /**
+     * Json Set Code
+     * 
+     * @param $data
+     * @throws \Exception
+     *
+     * @return void
+     */
     public function set($data)
     {
         if(is_array($data) || is_object($data)) {

--- a/lib/net/authorize/api/contract/v1/UpdateCustomerProfileRequest.php
+++ b/lib/net/authorize/api/contract/v1/UpdateCustomerProfileRequest.php
@@ -36,7 +36,11 @@ class UpdateCustomerProfileRequest extends ANetApiRequestType
     }
 
 
-    // Json Serialize Code
+    /**
+     * Json Serialize Code
+     * 
+     * @return array|mixed
+     */
     public function jsonSerialize(){
         $values = array_filter((array)get_object_vars($this),
         function ($val){

--- a/lib/net/authorize/api/contract/v1/UpdateCustomerProfileResponse.php
+++ b/lib/net/authorize/api/contract/v1/UpdateCustomerProfileResponse.php
@@ -8,8 +8,14 @@ namespace net\authorize\api\contract\v1;
 class UpdateCustomerProfileResponse extends ANetApiResponseType
 {
 
-
-    // Json Set Code
+    /**
+     * Json Set Code
+     *
+     * @param $data
+     * @throws \Exception
+     *
+     * @return void
+     */
     public function set($data)
     {
         if(is_array($data) || is_object($data)) {

--- a/lib/net/authorize/api/contract/v1/UpdateCustomerShippingAddressRequest.php
+++ b/lib/net/authorize/api/contract/v1/UpdateCustomerShippingAddressRequest.php
@@ -90,7 +90,11 @@ class UpdateCustomerShippingAddressRequest extends ANetApiRequestType
     }
 
 
-    // Json Serialize Code
+    /**
+     * Json Serialize Code
+     * 
+     * @return array|mixed
+     */
     public function jsonSerialize(){
         $values = array_filter((array)get_object_vars($this),
         function ($val){

--- a/lib/net/authorize/api/contract/v1/UpdateCustomerShippingAddressResponse.php
+++ b/lib/net/authorize/api/contract/v1/UpdateCustomerShippingAddressResponse.php
@@ -6,10 +6,16 @@ namespace net\authorize\api\contract\v1;
  * Class representing UpdateCustomerShippingAddressResponse
  */
 class UpdateCustomerShippingAddressResponse extends ANetApiResponseType
-{
+{ 
 
-
-    // Json Set Code
+    /**
+     * Json Set Code
+     * 
+     * @param $data
+     * @throws \Exception
+     *
+     * @return void
+     */
     public function set($data)
     {
         if(is_array($data) || is_object($data)) {

--- a/lib/net/authorize/api/contract/v1/UpdateHeldTransactionRequest.php
+++ b/lib/net/authorize/api/contract/v1/UpdateHeldTransactionRequest.php
@@ -38,7 +38,11 @@ class UpdateHeldTransactionRequest extends ANetApiRequestType
     }
 
 
-    // Json Serialize Code
+    /**
+     * Json Serialize Code
+     * 
+     * @return array|mixed
+     */
     public function jsonSerialize(){
         $values = array_filter((array)get_object_vars($this),
         function ($val){

--- a/lib/net/authorize/api/contract/v1/UpdateHeldTransactionResponse.php
+++ b/lib/net/authorize/api/contract/v1/UpdateHeldTransactionResponse.php
@@ -37,8 +37,14 @@ class UpdateHeldTransactionResponse extends ANetApiResponseType
         return $this;
     }
 
-
-    // Json Set Code
+    /**
+     * Json Set Code
+     *
+     * @param $data
+     * @throws \Exception
+     *
+     * @return void
+     */
     public function set($data)
     {
         if(is_array($data) || is_object($data)) {

--- a/lib/net/authorize/api/contract/v1/UpdateMerchantDetailsRequest.php
+++ b/lib/net/authorize/api/contract/v1/UpdateMerchantDetailsRequest.php
@@ -36,7 +36,11 @@ class UpdateMerchantDetailsRequest extends ANetApiRequestType
     }
 
 
-    // Json Serialize Code
+    /**
+     * Json Serialize Code
+     *
+     * @return array|mixed
+     */
     public function jsonSerialize(){
         $values = array_filter((array)get_object_vars($this),
         function ($val){

--- a/lib/net/authorize/api/contract/v1/UpdateMerchantDetailsResponse.php
+++ b/lib/net/authorize/api/contract/v1/UpdateMerchantDetailsResponse.php
@@ -6,10 +6,16 @@ namespace net\authorize\api\contract\v1;
  * Class representing UpdateMerchantDetailsResponse
  */
 class UpdateMerchantDetailsResponse extends ANetApiResponseType
-{
+{ 
 
-
-    // Json Set Code
+    /**
+     * Json Set Code
+     * 
+     * @param $data
+     * @throws \Exception
+     *
+     * @return void
+     */
     public function set($data)
     {
         if(is_array($data) || is_object($data)) {

--- a/lib/net/authorize/api/contract/v1/UpdateSplitTenderGroupRequest.php
+++ b/lib/net/authorize/api/contract/v1/UpdateSplitTenderGroupRequest.php
@@ -63,7 +63,11 @@ class UpdateSplitTenderGroupRequest extends ANetApiRequestType
     }
 
 
-    // Json Serialize Code
+    /**
+     * Json Serialize Code
+     *
+     * @return array|mixed
+     */
     public function jsonSerialize(){
         $values = array_filter((array)get_object_vars($this),
         function ($val){

--- a/lib/net/authorize/api/contract/v1/UpdateSplitTenderGroupResponse.php
+++ b/lib/net/authorize/api/contract/v1/UpdateSplitTenderGroupResponse.php
@@ -6,10 +6,16 @@ namespace net\authorize\api\contract\v1;
  * Class representing UpdateSplitTenderGroupResponse
  */
 class UpdateSplitTenderGroupResponse extends ANetApiResponseType
-{
+{ 
 
-
-    // Json Set Code
+    /**
+     * Json Set Code
+     * 
+     * @param $data
+     * @throws \Exception
+     *
+     * @return void
+     */
     public function set($data)
     {
         if(is_array($data) || is_object($data)) {

--- a/lib/net/authorize/api/contract/v1/UserFieldType.php
+++ b/lib/net/authorize/api/contract/v1/UserFieldType.php
@@ -66,7 +66,11 @@ class UserFieldType implements \JsonSerializable
     }
 
 
-    // Json Serialize Code
+    /**
+     * Json Serialize Code
+     *
+     * @return array|mixed
+     */
     public function jsonSerialize(){
         $values = array_filter((array)get_object_vars($this),
         function ($val){
@@ -100,8 +104,15 @@ class UserFieldType implements \JsonSerializable
             return array_merge(parent::jsonSerialize(), $values);
         }
     }
-    
-    // Json Set Code
+
+    /**
+     * Json Set Code
+     *
+     * @param $data
+     * @throws \Exception
+     *
+     * @return void
+     */
     public function set($data)
     {
         if(is_array($data) || is_object($data)) {

--- a/lib/net/authorize/api/contract/v1/ValidateCustomerPaymentProfileRequest.php
+++ b/lib/net/authorize/api/contract/v1/ValidateCustomerPaymentProfileRequest.php
@@ -144,7 +144,11 @@ class ValidateCustomerPaymentProfileRequest extends ANetApiRequestType
     }
 
 
-    // Json Serialize Code
+    /**
+     * Json Serialize Code
+     * 
+     * @return array|mixed
+     */
     public function jsonSerialize(){
         $values = array_filter((array)get_object_vars($this),
         function ($val){

--- a/lib/net/authorize/api/contract/v1/ValidateCustomerPaymentProfileResponse.php
+++ b/lib/net/authorize/api/contract/v1/ValidateCustomerPaymentProfileResponse.php
@@ -35,8 +35,14 @@ class ValidateCustomerPaymentProfileResponse extends ANetApiResponseType
         return $this;
     }
 
-
-    // Json Set Code
+    /**
+     * Json Set Code
+     *
+     * @param $data
+     * @throws \Exception
+     *
+     * @return void
+     */
     public function set($data)
     {
         if(is_array($data) || is_object($data)) {

--- a/lib/net/authorize/api/contract/v1/WebCheckOutDataType.php
+++ b/lib/net/authorize/api/contract/v1/WebCheckOutDataType.php
@@ -120,7 +120,11 @@ class WebCheckOutDataType implements \JsonSerializable
     }
 
 
-    // Json Serialize Code
+    /**
+     * Json Serialize Code
+     * 
+     * @return array|mixed
+     */
     public function jsonSerialize(){
         $values = array_filter((array)get_object_vars($this),
         function ($val){
@@ -153,9 +157,16 @@ class WebCheckOutDataType implements \JsonSerializable
         else{
             return array_merge(parent::jsonSerialize(), $values);
         }
-    }
-    
-    // Json Set Code
+    } 
+
+    /**
+     * Json Set Code
+     * 
+     * @param $data
+     * @throws \Exception
+     *
+     * @return void
+     */
     public function set($data)
     {
         if(is_array($data) || is_object($data)) {

--- a/lib/net/authorize/api/contract/v1/WebCheckOutDataTypeTokenType.php
+++ b/lib/net/authorize/api/contract/v1/WebCheckOutDataTypeTokenType.php
@@ -147,7 +147,11 @@ class WebCheckOutDataTypeTokenType implements \JsonSerializable
     }
 
 
-    // Json Serialize Code
+    /**
+     * Json Serialize Code
+     * 
+     * @return array|mixed
+     */
     public function jsonSerialize(){
         $values = array_filter((array)get_object_vars($this),
         function ($val){
@@ -180,9 +184,16 @@ class WebCheckOutDataTypeTokenType implements \JsonSerializable
         else{
             return array_merge(parent::jsonSerialize(), $values);
         }
-    }
-    
-    // Json Set Code
+    } 
+
+    /**
+     * Json Set Code
+     * 
+     * @param $data
+     * @throws \Exception
+     *
+     * @return void
+     */
     public function set($data)
     {
         if(is_array($data) || is_object($data)) {


### PR DESCRIPTION
Fixes:
- [ ] invalid doc block for jsonSerialize() and Json Set Code set() methods;
- [ ] magento 2 version above 2.3.x usage fix. Basically error connected to invalid doc blocks.