### PR TITLE
Updating generator to fix PHP74 related bug

### DIFF
--- a/scripts/appendJsonSerializeCode.pl
+++ b/scripts/appendJsonSerializeCode.pl
@@ -13,7 +13,13 @@ while (<>) {
     my $filepath = "lib/net/authorize/api/contract/v1/";
     my $filename = "$filepath"."$_";
     my $text = `cat $filename`;
-    my $sub = `cat scripts/appendJsonSerializeCode.txt`;
+    my $sub = "";
+
+    if ($text =~ /(?^pm:\nclass \w+ extends )/) {
+        $sub = `cat scripts/appendJsonSerializeSubClassCode.txt`;
+    } else {
+        $sub = `cat scripts/appendJsonSerializeCode.txt`;
+    }
 
     $text =~ s|(.+)}|$1$sub|xms;
 

--- a/scripts/appendJsonSerializeSubClassCode.txt
+++ b/scripts/appendJsonSerializeSubClassCode.txt
@@ -25,7 +25,7 @@
                 }
             }
         }
-        return $values;
+        return array_merge(parent::jsonSerialize(), $values);
     }
-    
+
 }


### PR DESCRIPTION
With PHP74 deprecation warnings are thrown when using any of the generated classes which don't have parents.
```
Deprecated: Cannot use "parent" when current class scope has no parent
```
This updates the generator to check if the class is a subclass when appending the jsonSerialize method.

---
https://github.com/AuthorizeNet/sdk-php/pull/382 https://github.com/AuthorizeNet/sdk-php/issues/383