### PR TITLE
Check class exists for string classname before checking for parent class

### DIFF
--- a/lib/net/authorize/util/Mapper.php
+++ b/lib/net/authorize/util/Mapper.php
@@ -86,7 +86,7 @@ class Mapper{
 
 			return $obj;
 		}
-		else if(get_parent_class($class)){
+		else if((is_object($class) || (is_string($class) && class_exists($class ))) && get_parent_class($class)){
             //echo "Checking parent class in YAML - ".get_parent_class($class)." -".$class." - ".$property."\n";
 			return $this->getClass(get_parent_class($class), $property);
 		}


### PR DESCRIPTION
Fixes:

`PHP Fatal error:  Uncaught TypeError: get_parent_class(): Argument #1 ($object_or_class) must be an object or a valid class name, string given in /../authorizenet/authorizenet/lib/net/authorize/util/Mapper.php:105`