### PR TITLE
Updating generator to for PHP81 compatibility

### DIFF
--- a/scripts/appendJsonSerializeCode.txt
+++ b/scripts/appendJsonSerializeCode.txt
@@ -1,4 +1,5 @@
     // Json Serialize Code
+    #[\ReturnTypeWillChange]
     public function jsonSerialize(){
         $values = array_filter((array)get_object_vars($this),
         function ($val){

--- a/scripts/appendJsonSerializeSubClassCode.txt
+++ b/scripts/appendJsonSerializeSubClassCode.txt
@@ -1,4 +1,5 @@
     // Json Serialize Code
+    #[\ReturnTypeWillChange]
     public function jsonSerialize(){
         $values = array_filter((array)get_object_vars($this),
         function ($val){


### PR DESCRIPTION
Supress PHP81 deprecation notices which are being thrown for generated classes implementing `jsonSerialize`.

```
Deprecated: Return type of ANetApiRequestType::jsonSerialize() should either be compatible with JsonSerializable::jsonSerialize(): mixed, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice
```

This updates the generator to add the `#[\ReturnTypeWillChange]` attribute to the generated jsonSerialize methods.