### PR TITLE
PHP 8.3 get_class() function deprecated without argument

### DIFF
--- a/lib/net/authorize/api/contract/v1/ANetApiRequestType.php
+++ b/lib/net/authorize/api/contract/v1/ANetApiRequestType.php
@@ -103,7 +103,7 @@ class ANetApiRequestType implements \JsonSerializable
         });
         $mapper = \net\authorize\util\Mapper::Instance();
         foreach($values as $key => $value){
-            $classDetails = $mapper->getClass(get_class() , $key);
+            $classDetails = $mapper->getClass(get_class($this) , $key);
             if (isset($value)){
                 if ($classDetails->className === 'Date'){
                     $dateTime = $value->format('Y-m-d');
@@ -131,7 +131,7 @@ class ANetApiRequestType implements \JsonSerializable
         if(is_array($data) || is_object($data)) {
 			$mapper = \net\authorize\util\Mapper::Instance();
 			foreach($data AS $key => $value) {
-				$classDetails = $mapper->getClass(get_class() , $key);
+				$classDetails = $mapper->getClass(get_class($this) , $key);
 	 
 				if($classDetails !== NULL ) {
 					if ($classDetails->isArray) {

--- a/lib/net/authorize/api/contract/v1/ANetApiResponseType.php
+++ b/lib/net/authorize/api/contract/v1/ANetApiResponseType.php
@@ -101,7 +101,7 @@ class ANetApiResponseType implements \JsonSerializable
         });
         $mapper = \net\authorize\util\Mapper::Instance();
         foreach($values as $key => $value){
-            $classDetails = $mapper->getClass(get_class() , $key);
+            $classDetails = $mapper->getClass(get_class($this) , $key);
             if (isset($value)){
                 if ($classDetails->className === 'Date'){
                     $dateTime = $value->format('Y-m-d');
@@ -129,7 +129,7 @@ class ANetApiResponseType implements \JsonSerializable
         if(is_array($data) || is_object($data)) {
 			$mapper = \net\authorize\util\Mapper::Instance();
 			foreach($data AS $key => $value) {
-				$classDetails = $mapper->getClass(get_class() , $key);
+				$classDetails = $mapper->getClass(get_class($this) , $key);
 	 
 				if($classDetails !== NULL ) {
 					if ($classDetails->isArray) {

--- a/lib/net/authorize/api/contract/v1/ARBCancelSubscriptionRequest.php
+++ b/lib/net/authorize/api/contract/v1/ARBCancelSubscriptionRequest.php
@@ -44,7 +44,7 @@ class ARBCancelSubscriptionRequest extends ANetApiRequestType
         });
         $mapper = \net\authorize\util\Mapper::Instance();
         foreach($values as $key => $value){
-            $classDetails = $mapper->getClass(get_class() , $key);
+            $classDetails = $mapper->getClass(get_class($this) , $key);
             if (isset($value)){
                 if ($classDetails->className === 'Date'){
                     $dateTime = $value->format('Y-m-d');

--- a/lib/net/authorize/api/contract/v1/ARBCancelSubscriptionResponse.php
+++ b/lib/net/authorize/api/contract/v1/ARBCancelSubscriptionResponse.php
@@ -15,7 +15,7 @@ class ARBCancelSubscriptionResponse extends ANetApiResponseType
         if(is_array($data) || is_object($data)) {
 			$mapper = \net\authorize\util\Mapper::Instance();
 			foreach($data AS $key => $value) {
-				$classDetails = $mapper->getClass(get_class() , $key);
+				$classDetails = $mapper->getClass(get_class($this) , $key);
 	 
 				if($classDetails !== NULL ) {
 					if ($classDetails->isArray) {

--- a/lib/net/authorize/api/contract/v1/ARBCreateSubscriptionRequest.php
+++ b/lib/net/authorize/api/contract/v1/ARBCreateSubscriptionRequest.php
@@ -44,7 +44,7 @@ class ARBCreateSubscriptionRequest extends ANetApiRequestType
         });
         $mapper = \net\authorize\util\Mapper::Instance();
         foreach($values as $key => $value){
-            $classDetails = $mapper->getClass(get_class() , $key);
+            $classDetails = $mapper->getClass(get_class($this) , $key);
             if (isset($value)){
                 if ($classDetails->className === 'Date'){
                     $dateTime = $value->format('Y-m-d');

--- a/lib/net/authorize/api/contract/v1/ARBCreateSubscriptionResponse.php
+++ b/lib/net/authorize/api/contract/v1/ARBCreateSubscriptionResponse.php
@@ -69,7 +69,7 @@ class ARBCreateSubscriptionResponse extends ANetApiResponseType
         if(is_array($data) || is_object($data)) {
 			$mapper = \net\authorize\util\Mapper::Instance();
 			foreach($data AS $key => $value) {
-				$classDetails = $mapper->getClass(get_class() , $key);
+				$classDetails = $mapper->getClass(get_class($this) , $key);
 	 
 				if($classDetails !== NULL ) {
 					if ($classDetails->isArray) {

--- a/lib/net/authorize/api/contract/v1/ARBGetSubscriptionListRequest.php
+++ b/lib/net/authorize/api/contract/v1/ARBGetSubscriptionListRequest.php
@@ -99,7 +99,7 @@ class ARBGetSubscriptionListRequest extends ANetApiRequestType
         });
         $mapper = \net\authorize\util\Mapper::Instance();
         foreach($values as $key => $value){
-            $classDetails = $mapper->getClass(get_class() , $key);
+            $classDetails = $mapper->getClass(get_class($this) , $key);
             if (isset($value)){
                 if ($classDetails->className === 'Date'){
                     $dateTime = $value->format('Y-m-d');

--- a/lib/net/authorize/api/contract/v1/ARBGetSubscriptionListResponse.php
+++ b/lib/net/authorize/api/contract/v1/ARBGetSubscriptionListResponse.php
@@ -105,7 +105,7 @@ class ARBGetSubscriptionListResponse extends ANetApiResponseType
         if(is_array($data) || is_object($data)) {
 			$mapper = \net\authorize\util\Mapper::Instance();
 			foreach($data AS $key => $value) {
-				$classDetails = $mapper->getClass(get_class() , $key);
+				$classDetails = $mapper->getClass(get_class($this) , $key);
 	 
 				if($classDetails !== NULL ) {
 					if ($classDetails->isArray) {

--- a/lib/net/authorize/api/contract/v1/ARBGetSubscriptionListSortingType.php
+++ b/lib/net/authorize/api/contract/v1/ARBGetSubscriptionListSortingType.php
@@ -74,7 +74,7 @@ class ARBGetSubscriptionListSortingType implements \JsonSerializable
         });
         $mapper = \net\authorize\util\Mapper::Instance();
         foreach($values as $key => $value){
-            $classDetails = $mapper->getClass(get_class() , $key);
+            $classDetails = $mapper->getClass(get_class($this) , $key);
             if (isset($value)){
                 if ($classDetails->className === 'Date'){
                     $dateTime = $value->format('Y-m-d');
@@ -102,7 +102,7 @@ class ARBGetSubscriptionListSortingType implements \JsonSerializable
         if(is_array($data) || is_object($data)) {
 			$mapper = \net\authorize\util\Mapper::Instance();
 			foreach($data AS $key => $value) {
-				$classDetails = $mapper->getClass(get_class() , $key);
+				$classDetails = $mapper->getClass(get_class($this) , $key);
 	 
 				if($classDetails !== NULL ) {
 					if ($classDetails->isArray) {

--- a/lib/net/authorize/api/contract/v1/ARBGetSubscriptionRequest.php
+++ b/lib/net/authorize/api/contract/v1/ARBGetSubscriptionRequest.php
@@ -71,7 +71,7 @@ class ARBGetSubscriptionRequest extends ANetApiRequestType
         });
         $mapper = \net\authorize\util\Mapper::Instance();
         foreach($values as $key => $value){
-            $classDetails = $mapper->getClass(get_class() , $key);
+            $classDetails = $mapper->getClass(get_class($this) , $key);
             if (isset($value)){
                 if ($classDetails->className === 'Date'){
                     $dateTime = $value->format('Y-m-d');

--- a/lib/net/authorize/api/contract/v1/ARBGetSubscriptionResponse.php
+++ b/lib/net/authorize/api/contract/v1/ARBGetSubscriptionResponse.php
@@ -42,7 +42,7 @@ class ARBGetSubscriptionResponse extends ANetApiResponseType
         if(is_array($data) || is_object($data)) {
 			$mapper = \net\authorize\util\Mapper::Instance();
 			foreach($data AS $key => $value) {
-				$classDetails = $mapper->getClass(get_class() , $key);
+				$classDetails = $mapper->getClass(get_class($this) , $key);
 	 
 				if($classDetails !== NULL ) {
 					if ($classDetails->isArray) {

--- a/lib/net/authorize/api/contract/v1/ARBGetSubscriptionStatusRequest.php
+++ b/lib/net/authorize/api/contract/v1/ARBGetSubscriptionStatusRequest.php
@@ -44,7 +44,7 @@ class ARBGetSubscriptionStatusRequest extends ANetApiRequestType
         });
         $mapper = \net\authorize\util\Mapper::Instance();
         foreach($values as $key => $value){
-            $classDetails = $mapper->getClass(get_class() , $key);
+            $classDetails = $mapper->getClass(get_class($this) , $key);
             if (isset($value)){
                 if ($classDetails->className === 'Date'){
                     $dateTime = $value->format('Y-m-d');

--- a/lib/net/authorize/api/contract/v1/ARBGetSubscriptionStatusResponse.php
+++ b/lib/net/authorize/api/contract/v1/ARBGetSubscriptionStatusResponse.php
@@ -42,7 +42,7 @@ class ARBGetSubscriptionStatusResponse extends ANetApiResponseType
         if(is_array($data) || is_object($data)) {
 			$mapper = \net\authorize\util\Mapper::Instance();
 			foreach($data AS $key => $value) {
-				$classDetails = $mapper->getClass(get_class() , $key);
+				$classDetails = $mapper->getClass(get_class($this) , $key);
 	 
 				if($classDetails !== NULL ) {
 					if ($classDetails->isArray) {

--- a/lib/net/authorize/api/contract/v1/ARBSubscriptionMaskedType.php
+++ b/lib/net/authorize/api/contract/v1/ARBSubscriptionMaskedType.php
@@ -271,7 +271,7 @@ class ARBSubscriptionMaskedType implements \JsonSerializable
         });
         $mapper = \net\authorize\util\Mapper::Instance();
         foreach($values as $key => $value){
-            $classDetails = $mapper->getClass(get_class() , $key);
+            $classDetails = $mapper->getClass(get_class($this) , $key);
             if (isset($value)){
                 if ($classDetails->className === 'Date'){
                     $dateTime = $value->format('Y-m-d');
@@ -299,7 +299,7 @@ class ARBSubscriptionMaskedType implements \JsonSerializable
         if(is_array($data) || is_object($data)) {
 			$mapper = \net\authorize\util\Mapper::Instance();
 			foreach($data AS $key => $value) {
-				$classDetails = $mapper->getClass(get_class() , $key);
+				$classDetails = $mapper->getClass(get_class($this) , $key);
 	 
 				if($classDetails !== NULL ) {
 					if ($classDetails->isArray) {

--- a/lib/net/authorize/api/contract/v1/ARBSubscriptionType.php
+++ b/lib/net/authorize/api/contract/v1/ARBSubscriptionType.php
@@ -290,7 +290,7 @@ class ARBSubscriptionType implements \JsonSerializable
         });
         $mapper = \net\authorize\util\Mapper::Instance();
         foreach($values as $key => $value){
-            $classDetails = $mapper->getClass(get_class() , $key);
+            $classDetails = $mapper->getClass(get_class($this) , $key);
             if (isset($value)){
                 if ($classDetails->className === 'Date'){
                     $dateTime = $value->format('Y-m-d');
@@ -318,7 +318,7 @@ class ARBSubscriptionType implements \JsonSerializable
         if(is_array($data) || is_object($data)) {
 			$mapper = \net\authorize\util\Mapper::Instance();
 			foreach($data AS $key => $value) {
-				$classDetails = $mapper->getClass(get_class() , $key);
+				$classDetails = $mapper->getClass(get_class($this) , $key);
 	 
 				if($classDetails !== NULL ) {
 					if ($classDetails->isArray) {

--- a/lib/net/authorize/api/contract/v1/ARBUpdateSubscriptionRequest.php
+++ b/lib/net/authorize/api/contract/v1/ARBUpdateSubscriptionRequest.php
@@ -71,7 +71,7 @@ class ARBUpdateSubscriptionRequest extends ANetApiRequestType
         });
         $mapper = \net\authorize\util\Mapper::Instance();
         foreach($values as $key => $value){
-            $classDetails = $mapper->getClass(get_class() , $key);
+            $classDetails = $mapper->getClass(get_class($this) , $key);
             if (isset($value)){
                 if ($classDetails->className === 'Date'){
                     $dateTime = $value->format('Y-m-d');

--- a/lib/net/authorize/api/contract/v1/ARBUpdateSubscriptionResponse.php
+++ b/lib/net/authorize/api/contract/v1/ARBUpdateSubscriptionResponse.php
@@ -42,7 +42,7 @@ class ARBUpdateSubscriptionResponse extends ANetApiResponseType
         if(is_array($data) || is_object($data)) {
 			$mapper = \net\authorize\util\Mapper::Instance();
 			foreach($data AS $key => $value) {
-				$classDetails = $mapper->getClass(get_class() , $key);
+				$classDetails = $mapper->getClass(get_class($this) , $key);
 	 
 				if($classDetails !== NULL ) {
 					if ($classDetails->isArray) {

--- a/lib/net/authorize/api/contract/v1/ArbTransactionType.php
+++ b/lib/net/authorize/api/contract/v1/ArbTransactionType.php
@@ -155,7 +155,7 @@ class ArbTransactionType implements \JsonSerializable
         });
         $mapper = \net\authorize\util\Mapper::Instance();
         foreach($values as $key => $value){
-            $classDetails = $mapper->getClass(get_class() , $key);
+            $classDetails = $mapper->getClass(get_class($this) , $key);
             if (isset($value)){
                 if ($classDetails->className === 'Date'){
                     $dateTime = $value->format('Y-m-d');
@@ -183,7 +183,7 @@ class ArbTransactionType implements \JsonSerializable
         if(is_array($data) || is_object($data)) {
 			$mapper = \net\authorize\util\Mapper::Instance();
 			foreach($data AS $key => $value) {
-				$classDetails = $mapper->getClass(get_class() , $key);
+				$classDetails = $mapper->getClass(get_class($this) , $key);
 	 
 				if($classDetails !== NULL ) {
 					if ($classDetails->isArray) {

--- a/lib/net/authorize/api/contract/v1/ArrayOfSettingType.php
+++ b/lib/net/authorize/api/contract/v1/ArrayOfSettingType.php
@@ -81,7 +81,7 @@ class ArrayOfSettingType implements \JsonSerializable
         });
         $mapper = \net\authorize\util\Mapper::Instance();
         foreach($values as $key => $value){
-            $classDetails = $mapper->getClass(get_class() , $key);
+            $classDetails = $mapper->getClass(get_class($this) , $key);
             if (isset($value)){
                 if ($classDetails->className === 'Date'){
                     $dateTime = $value->format('Y-m-d');
@@ -109,7 +109,7 @@ class ArrayOfSettingType implements \JsonSerializable
         if(is_array($data) || is_object($data)) {
 			$mapper = \net\authorize\util\Mapper::Instance();
 			foreach($data AS $key => $value) {
-				$classDetails = $mapper->getClass(get_class() , $key);
+				$classDetails = $mapper->getClass(get_class($this) , $key);
 	 
 				if($classDetails !== NULL ) {
 					if ($classDetails->isArray) {

--- a/lib/net/authorize/api/contract/v1/AuDeleteType.php
+++ b/lib/net/authorize/api/contract/v1/AuDeleteType.php
@@ -47,7 +47,7 @@ class AuDeleteType extends AuDetailsType implements \JsonSerializable
         });
         $mapper = \net\authorize\util\Mapper::Instance();
         foreach($values as $key => $value){
-            $classDetails = $mapper->getClass(get_class() , $key);
+            $classDetails = $mapper->getClass(get_class($this) , $key);
             if (isset($value)){
                 if ($classDetails->className === 'Date'){
                     $dateTime = $value->format('Y-m-d');
@@ -75,7 +75,7 @@ class AuDeleteType extends AuDetailsType implements \JsonSerializable
         if(is_array($data) || is_object($data)) {
 			$mapper = \net\authorize\util\Mapper::Instance();
 			foreach($data AS $key => $value) {
-				$classDetails = $mapper->getClass(get_class() , $key);
+				$classDetails = $mapper->getClass(get_class($this) , $key);
 	 
 				if($classDetails !== NULL ) {
 					if ($classDetails->isArray) {

--- a/lib/net/authorize/api/contract/v1/AuDetailsType.php
+++ b/lib/net/authorize/api/contract/v1/AuDetailsType.php
@@ -209,7 +209,7 @@ class AuDetailsType implements \JsonSerializable
         });
         $mapper = \net\authorize\util\Mapper::Instance();
         foreach($values as $key => $value){
-            $classDetails = $mapper->getClass(get_class() , $key);
+            $classDetails = $mapper->getClass(get_class($this) , $key);
             if (isset($value)){
                 if ($classDetails->className === 'Date'){
                     $dateTime = $value->format('Y-m-d');
@@ -237,7 +237,7 @@ class AuDetailsType implements \JsonSerializable
         if(is_array($data) || is_object($data)) {
 			$mapper = \net\authorize\util\Mapper::Instance();
 			foreach($data AS $key => $value) {
-				$classDetails = $mapper->getClass(get_class() , $key);
+				$classDetails = $mapper->getClass(get_class($this) , $key);
 	 
 				if($classDetails !== NULL ) {
 					if ($classDetails->isArray) {

--- a/lib/net/authorize/api/contract/v1/AuResponseType.php
+++ b/lib/net/authorize/api/contract/v1/AuResponseType.php
@@ -101,7 +101,7 @@ class AuResponseType implements \JsonSerializable
         });
         $mapper = \net\authorize\util\Mapper::Instance();
         foreach($values as $key => $value){
-            $classDetails = $mapper->getClass(get_class() , $key);
+            $classDetails = $mapper->getClass(get_class($this) , $key);
             if (isset($value)){
                 if ($classDetails->className === 'Date'){
                     $dateTime = $value->format('Y-m-d');
@@ -129,7 +129,7 @@ class AuResponseType implements \JsonSerializable
         if(is_array($data) || is_object($data)) {
 			$mapper = \net\authorize\util\Mapper::Instance();
 			foreach($data AS $key => $value) {
-				$classDetails = $mapper->getClass(get_class() , $key);
+				$classDetails = $mapper->getClass(get_class($this) , $key);
 	 
 				if($classDetails !== NULL ) {
 					if ($classDetails->isArray) {

--- a/lib/net/authorize/api/contract/v1/AuUpdateType.php
+++ b/lib/net/authorize/api/contract/v1/AuUpdateType.php
@@ -74,7 +74,7 @@ class AuUpdateType extends AuDetailsType implements \JsonSerializable
         });
         $mapper = \net\authorize\util\Mapper::Instance();
         foreach($values as $key => $value){
-            $classDetails = $mapper->getClass(get_class() , $key);
+            $classDetails = $mapper->getClass(get_class($this) , $key);
             if (isset($value)){
                 if ($classDetails->className === 'Date'){
                     $dateTime = $value->format('Y-m-d');
@@ -102,7 +102,7 @@ class AuUpdateType extends AuDetailsType implements \JsonSerializable
         if(is_array($data) || is_object($data)) {
 			$mapper = \net\authorize\util\Mapper::Instance();
 			foreach($data AS $key => $value) {
-				$classDetails = $mapper->getClass(get_class() , $key);
+				$classDetails = $mapper->getClass(get_class($this) , $key);
 	 
 				if($classDetails !== NULL ) {
 					if ($classDetails->isArray) {

--- a/lib/net/authorize/api/contract/v1/AuthenticateTestRequest.php
+++ b/lib/net/authorize/api/contract/v1/AuthenticateTestRequest.php
@@ -17,7 +17,7 @@ class AuthenticateTestRequest extends ANetApiRequestType
         });
         $mapper = \net\authorize\util\Mapper::Instance();
         foreach($values as $key => $value){
-            $classDetails = $mapper->getClass(get_class() , $key);
+            $classDetails = $mapper->getClass(get_class($this) , $key);
             if (isset($value)){
                 if ($classDetails->className === 'Date'){
                     $dateTime = $value->format('Y-m-d');

--- a/lib/net/authorize/api/contract/v1/AuthenticateTestResponse.php
+++ b/lib/net/authorize/api/contract/v1/AuthenticateTestResponse.php
@@ -15,7 +15,7 @@ class AuthenticateTestResponse extends ANetApiResponseType
         if(is_array($data) || is_object($data)) {
 			$mapper = \net\authorize\util\Mapper::Instance();
 			foreach($data AS $key => $value) {
-				$classDetails = $mapper->getClass(get_class() , $key);
+				$classDetails = $mapper->getClass(get_class($this) , $key);
 	 
 				if($classDetails !== NULL ) {
 					if ($classDetails->isArray) {

--- a/lib/net/authorize/api/contract/v1/AuthorizationIndicatorType.php
+++ b/lib/net/authorize/api/contract/v1/AuthorizationIndicatorType.php
@@ -47,7 +47,7 @@ class AuthorizationIndicatorType implements \JsonSerializable
         });
         $mapper = \net\authorize\util\Mapper::Instance();
         foreach($values as $key => $value){
-            $classDetails = $mapper->getClass(get_class() , $key);
+            $classDetails = $mapper->getClass(get_class($this) , $key);
             if (isset($value)){
                 if ($classDetails->className === 'Date'){
                     $dateTime = $value->format('Y-m-d');
@@ -75,7 +75,7 @@ class AuthorizationIndicatorType implements \JsonSerializable
         if(is_array($data) || is_object($data)) {
 			$mapper = \net\authorize\util\Mapper::Instance();
 			foreach($data AS $key => $value) {
-				$classDetails = $mapper->getClass(get_class() , $key);
+				$classDetails = $mapper->getClass(get_class($this) , $key);
 	 
 				if($classDetails !== NULL ) {
 					if ($classDetails->isArray) {

--- a/lib/net/authorize/api/contract/v1/BankAccountMaskedType.php
+++ b/lib/net/authorize/api/contract/v1/BankAccountMaskedType.php
@@ -182,7 +182,7 @@ class BankAccountMaskedType implements \JsonSerializable
         });
         $mapper = \net\authorize\util\Mapper::Instance();
         foreach($values as $key => $value){
-            $classDetails = $mapper->getClass(get_class() , $key);
+            $classDetails = $mapper->getClass(get_class($this) , $key);
             if (isset($value)){
                 if ($classDetails->className === 'Date'){
                     $dateTime = $value->format('Y-m-d');
@@ -210,7 +210,7 @@ class BankAccountMaskedType implements \JsonSerializable
         if(is_array($data) || is_object($data)) {
 			$mapper = \net\authorize\util\Mapper::Instance();
 			foreach($data AS $key => $value) {
-				$classDetails = $mapper->getClass(get_class() , $key);
+				$classDetails = $mapper->getClass(get_class($this) , $key);
 	 
 				if($classDetails !== NULL ) {
 					if ($classDetails->isArray) {

--- a/lib/net/authorize/api/contract/v1/BankAccountType.php
+++ b/lib/net/authorize/api/contract/v1/BankAccountType.php
@@ -209,7 +209,7 @@ class BankAccountType implements \JsonSerializable
         });
         $mapper = \net\authorize\util\Mapper::Instance();
         foreach($values as $key => $value){
-            $classDetails = $mapper->getClass(get_class() , $key);
+            $classDetails = $mapper->getClass(get_class($this) , $key);
             if (isset($value)){
                 if ($classDetails->className === 'Date'){
                     $dateTime = $value->format('Y-m-d');
@@ -237,7 +237,7 @@ class BankAccountType implements \JsonSerializable
         if(is_array($data) || is_object($data)) {
 			$mapper = \net\authorize\util\Mapper::Instance();
 			foreach($data AS $key => $value) {
-				$classDetails = $mapper->getClass(get_class() , $key);
+				$classDetails = $mapper->getClass(get_class($this) , $key);
 	 
 				if($classDetails !== NULL ) {
 					if ($classDetails->isArray) {

--- a/lib/net/authorize/api/contract/v1/BatchDetailsType.php
+++ b/lib/net/authorize/api/contract/v1/BatchDetailsType.php
@@ -270,7 +270,7 @@ class BatchDetailsType implements \JsonSerializable
         });
         $mapper = \net\authorize\util\Mapper::Instance();
         foreach($values as $key => $value){
-            $classDetails = $mapper->getClass(get_class() , $key);
+            $classDetails = $mapper->getClass(get_class($this) , $key);
             if (isset($value)){
                 if ($classDetails->className === 'Date'){
                     $dateTime = $value->format('Y-m-d');
@@ -298,7 +298,7 @@ class BatchDetailsType implements \JsonSerializable
         if(is_array($data) || is_object($data)) {
 			$mapper = \net\authorize\util\Mapper::Instance();
 			foreach($data AS $key => $value) {
-				$classDetails = $mapper->getClass(get_class() , $key);
+				$classDetails = $mapper->getClass(get_class($this) , $key);
 	 
 				if($classDetails !== NULL ) {
 					if ($classDetails->isArray) {

--- a/lib/net/authorize/api/contract/v1/BatchStatisticType.php
+++ b/lib/net/authorize/api/contract/v1/BatchStatisticType.php
@@ -587,7 +587,7 @@ class BatchStatisticType implements \JsonSerializable
         });
         $mapper = \net\authorize\util\Mapper::Instance();
         foreach($values as $key => $value){
-            $classDetails = $mapper->getClass(get_class() , $key);
+            $classDetails = $mapper->getClass(get_class($this) , $key);
             if (isset($value)){
                 if ($classDetails->className === 'Date'){
                     $dateTime = $value->format('Y-m-d');
@@ -615,7 +615,7 @@ class BatchStatisticType implements \JsonSerializable
         if(is_array($data) || is_object($data)) {
 			$mapper = \net\authorize\util\Mapper::Instance();
 			foreach($data AS $key => $value) {
-				$classDetails = $mapper->getClass(get_class() , $key);
+				$classDetails = $mapper->getClass(get_class($this) , $key);
 	 
 				if($classDetails !== NULL ) {
 					if ($classDetails->isArray) {

--- a/lib/net/authorize/api/contract/v1/CardArtType.php
+++ b/lib/net/authorize/api/contract/v1/CardArtType.php
@@ -155,7 +155,7 @@ class CardArtType implements \JsonSerializable
         });
         $mapper = \net\authorize\util\Mapper::Instance();
         foreach($values as $key => $value){
-            $classDetails = $mapper->getClass(get_class() , $key);
+            $classDetails = $mapper->getClass(get_class($this) , $key);
             if (isset($value)){
                 if ($classDetails->className === 'Date'){
                     $dateTime = $value->format('Y-m-d');
@@ -183,7 +183,7 @@ class CardArtType implements \JsonSerializable
         if(is_array($data) || is_object($data)) {
 			$mapper = \net\authorize\util\Mapper::Instance();
 			foreach($data AS $key => $value) {
-				$classDetails = $mapper->getClass(get_class() , $key);
+				$classDetails = $mapper->getClass(get_class($this) , $key);
 	 
 				if($classDetails !== NULL ) {
 					if ($classDetails->isArray) {

--- a/lib/net/authorize/api/contract/v1/CcAuthenticationType.php
+++ b/lib/net/authorize/api/contract/v1/CcAuthenticationType.php
@@ -74,7 +74,7 @@ class CcAuthenticationType implements \JsonSerializable
         });
         $mapper = \net\authorize\util\Mapper::Instance();
         foreach($values as $key => $value){
-            $classDetails = $mapper->getClass(get_class() , $key);
+            $classDetails = $mapper->getClass(get_class($this) , $key);
             if (isset($value)){
                 if ($classDetails->className === 'Date'){
                     $dateTime = $value->format('Y-m-d');
@@ -102,7 +102,7 @@ class CcAuthenticationType implements \JsonSerializable
         if(is_array($data) || is_object($data)) {
 			$mapper = \net\authorize\util\Mapper::Instance();
 			foreach($data AS $key => $value) {
-				$classDetails = $mapper->getClass(get_class() , $key);
+				$classDetails = $mapper->getClass(get_class($this) , $key);
 	 
 				if($classDetails !== NULL ) {
 					if ($classDetails->isArray) {

--- a/lib/net/authorize/api/contract/v1/ContactDetailType.php
+++ b/lib/net/authorize/api/contract/v1/ContactDetailType.php
@@ -101,7 +101,7 @@ class ContactDetailType implements \JsonSerializable
         });
         $mapper = \net\authorize\util\Mapper::Instance();
         foreach($values as $key => $value){
-            $classDetails = $mapper->getClass(get_class() , $key);
+            $classDetails = $mapper->getClass(get_class($this) , $key);
             if (isset($value)){
                 if ($classDetails->className === 'Date'){
                     $dateTime = $value->format('Y-m-d');
@@ -129,7 +129,7 @@ class ContactDetailType implements \JsonSerializable
         if(is_array($data) || is_object($data)) {
 			$mapper = \net\authorize\util\Mapper::Instance();
 			foreach($data AS $key => $value) {
-				$classDetails = $mapper->getClass(get_class() , $key);
+				$classDetails = $mapper->getClass(get_class($this) , $key);
 	 
 				if($classDetails !== NULL ) {
 					if ($classDetails->isArray) {

--- a/lib/net/authorize/api/contract/v1/CreateCustomerPaymentProfileRequest.php
+++ b/lib/net/authorize/api/contract/v1/CreateCustomerPaymentProfileRequest.php
@@ -99,7 +99,7 @@ class CreateCustomerPaymentProfileRequest extends ANetApiRequestType
         });
         $mapper = \net\authorize\util\Mapper::Instance();
         foreach($values as $key => $value){
-            $classDetails = $mapper->getClass(get_class() , $key);
+            $classDetails = $mapper->getClass(get_class($this) , $key);
             if (isset($value)){
                 if ($classDetails->className === 'Date'){
                     $dateTime = $value->format('Y-m-d');

--- a/lib/net/authorize/api/contract/v1/CreateCustomerPaymentProfileResponse.php
+++ b/lib/net/authorize/api/contract/v1/CreateCustomerPaymentProfileResponse.php
@@ -96,7 +96,7 @@ class CreateCustomerPaymentProfileResponse extends ANetApiResponseType
         if(is_array($data) || is_object($data)) {
 			$mapper = \net\authorize\util\Mapper::Instance();
 			foreach($data AS $key => $value) {
-				$classDetails = $mapper->getClass(get_class() , $key);
+				$classDetails = $mapper->getClass(get_class($this) , $key);
 	 
 				if($classDetails !== NULL ) {
 					if ($classDetails->isArray) {

--- a/lib/net/authorize/api/contract/v1/CreateCustomerProfileFromTransactionRequest.php
+++ b/lib/net/authorize/api/contract/v1/CreateCustomerProfileFromTransactionRequest.php
@@ -179,7 +179,7 @@ class CreateCustomerProfileFromTransactionRequest extends ANetApiRequestType
         });
         $mapper = \net\authorize\util\Mapper::Instance();
         foreach($values as $key => $value){
-            $classDetails = $mapper->getClass(get_class() , $key);
+            $classDetails = $mapper->getClass(get_class($this) , $key);
             if (isset($value)){
                 if ($classDetails->className === 'Date'){
                     $dateTime = $value->format('Y-m-d');

--- a/lib/net/authorize/api/contract/v1/CreateCustomerProfileRequest.php
+++ b/lib/net/authorize/api/contract/v1/CreateCustomerProfileRequest.php
@@ -71,7 +71,7 @@ class CreateCustomerProfileRequest extends ANetApiRequestType
         });
         $mapper = \net\authorize\util\Mapper::Instance();
         foreach($values as $key => $value){
-            $classDetails = $mapper->getClass(get_class() , $key);
+            $classDetails = $mapper->getClass(get_class($this) , $key);
             if (isset($value)){
                 if ($classDetails->className === 'Date'){
                     $dateTime = $value->format('Y-m-d');

--- a/lib/net/authorize/api/contract/v1/CreateCustomerProfileResponse.php
+++ b/lib/net/authorize/api/contract/v1/CreateCustomerProfileResponse.php
@@ -225,7 +225,7 @@ class CreateCustomerProfileResponse extends ANetApiResponseType
         if(is_array($data) || is_object($data)) {
 			$mapper = \net\authorize\util\Mapper::Instance();
 			foreach($data AS $key => $value) {
-				$classDetails = $mapper->getClass(get_class() , $key);
+				$classDetails = $mapper->getClass(get_class($this) , $key);
 	 
 				if($classDetails !== NULL ) {
 					if ($classDetails->isArray) {

--- a/lib/net/authorize/api/contract/v1/CreateCustomerProfileTransactionRequest.php
+++ b/lib/net/authorize/api/contract/v1/CreateCustomerProfileTransactionRequest.php
@@ -71,7 +71,7 @@ class CreateCustomerProfileTransactionRequest extends ANetApiRequestType
         });
         $mapper = \net\authorize\util\Mapper::Instance();
         foreach($values as $key => $value){
-            $classDetails = $mapper->getClass(get_class() , $key);
+            $classDetails = $mapper->getClass(get_class($this) , $key);
             if (isset($value)){
                 if ($classDetails->className === 'Date'){
                     $dateTime = $value->format('Y-m-d');

--- a/lib/net/authorize/api/contract/v1/CreateCustomerProfileTransactionResponse.php
+++ b/lib/net/authorize/api/contract/v1/CreateCustomerProfileTransactionResponse.php
@@ -71,7 +71,7 @@ class CreateCustomerProfileTransactionResponse extends ANetApiResponseType
         if(is_array($data) || is_object($data)) {
 			$mapper = \net\authorize\util\Mapper::Instance();
 			foreach($data AS $key => $value) {
-				$classDetails = $mapper->getClass(get_class() , $key);
+				$classDetails = $mapper->getClass(get_class($this) , $key);
 	 
 				if($classDetails !== NULL ) {
 					if ($classDetails->isArray) {

--- a/lib/net/authorize/api/contract/v1/CreateCustomerShippingAddressRequest.php
+++ b/lib/net/authorize/api/contract/v1/CreateCustomerShippingAddressRequest.php
@@ -98,7 +98,7 @@ class CreateCustomerShippingAddressRequest extends ANetApiRequestType
         });
         $mapper = \net\authorize\util\Mapper::Instance();
         foreach($values as $key => $value){
-            $classDetails = $mapper->getClass(get_class() , $key);
+            $classDetails = $mapper->getClass(get_class($this) , $key);
             if (isset($value)){
                 if ($classDetails->className === 'Date'){
                     $dateTime = $value->format('Y-m-d');

--- a/lib/net/authorize/api/contract/v1/CreateCustomerShippingAddressResponse.php
+++ b/lib/net/authorize/api/contract/v1/CreateCustomerShippingAddressResponse.php
@@ -69,7 +69,7 @@ class CreateCustomerShippingAddressResponse extends ANetApiResponseType
         if(is_array($data) || is_object($data)) {
 			$mapper = \net\authorize\util\Mapper::Instance();
 			foreach($data AS $key => $value) {
-				$classDetails = $mapper->getClass(get_class() , $key);
+				$classDetails = $mapper->getClass(get_class($this) , $key);
 	 
 				if($classDetails !== NULL ) {
 					if ($classDetails->isArray) {

--- a/lib/net/authorize/api/contract/v1/CreateProfileResponseType.php
+++ b/lib/net/authorize/api/contract/v1/CreateProfileResponseType.php
@@ -196,7 +196,7 @@ class CreateProfileResponseType implements \JsonSerializable
         });
         $mapper = \net\authorize\util\Mapper::Instance();
         foreach($values as $key => $value){
-            $classDetails = $mapper->getClass(get_class() , $key);
+            $classDetails = $mapper->getClass(get_class($this) , $key);
             if (isset($value)){
                 if ($classDetails->className === 'Date'){
                     $dateTime = $value->format('Y-m-d');
@@ -224,7 +224,7 @@ class CreateProfileResponseType implements \JsonSerializable
         if(is_array($data) || is_object($data)) {
 			$mapper = \net\authorize\util\Mapper::Instance();
 			foreach($data AS $key => $value) {
-				$classDetails = $mapper->getClass(get_class() , $key);
+				$classDetails = $mapper->getClass(get_class($this) , $key);
 	 
 				if($classDetails !== NULL ) {
 					if ($classDetails->isArray) {

--- a/lib/net/authorize/api/contract/v1/CreateTransactionRequest.php
+++ b/lib/net/authorize/api/contract/v1/CreateTransactionRequest.php
@@ -45,7 +45,7 @@ class CreateTransactionRequest extends ANetApiRequestType
         });
         $mapper = \net\authorize\util\Mapper::Instance();
         foreach($values as $key => $value){
-            $classDetails = $mapper->getClass(get_class() , $key);
+            $classDetails = $mapper->getClass(get_class($this) , $key);
             if (isset($value)){
                 if ($classDetails->className === 'Date'){
                     $dateTime = $value->format('Y-m-d');

--- a/lib/net/authorize/api/contract/v1/CreateTransactionResponse.php
+++ b/lib/net/authorize/api/contract/v1/CreateTransactionResponse.php
@@ -72,7 +72,7 @@ class CreateTransactionResponse extends ANetApiResponseType
         if(is_array($data) || is_object($data)) {
 			$mapper = \net\authorize\util\Mapper::Instance();
 			foreach($data AS $key => $value) {
-				$classDetails = $mapper->getClass(get_class() , $key);
+				$classDetails = $mapper->getClass(get_class($this) , $key);
 	 
 				if($classDetails !== NULL ) {
 					if ($classDetails->isArray) {

--- a/lib/net/authorize/api/contract/v1/CreditCardMaskedType.php
+++ b/lib/net/authorize/api/contract/v1/CreditCardMaskedType.php
@@ -182,7 +182,7 @@ class CreditCardMaskedType implements \JsonSerializable
         });
         $mapper = \net\authorize\util\Mapper::Instance();
         foreach($values as $key => $value){
-            $classDetails = $mapper->getClass(get_class() , $key);
+            $classDetails = $mapper->getClass(get_class($this) , $key);
             if (isset($value)){
                 if ($classDetails->className === 'Date'){
                     $dateTime = $value->format('Y-m-d');
@@ -210,7 +210,7 @@ class CreditCardMaskedType implements \JsonSerializable
         if(is_array($data) || is_object($data)) {
 			$mapper = \net\authorize\util\Mapper::Instance();
 			foreach($data AS $key => $value) {
-				$classDetails = $mapper->getClass(get_class() , $key);
+				$classDetails = $mapper->getClass(get_class($this) , $key);
 	 
 				if($classDetails !== NULL ) {
 					if ($classDetails->isArray) {

--- a/lib/net/authorize/api/contract/v1/CreditCardSimpleType.php
+++ b/lib/net/authorize/api/contract/v1/CreditCardSimpleType.php
@@ -74,7 +74,7 @@ class CreditCardSimpleType implements \JsonSerializable
         });
         $mapper = \net\authorize\util\Mapper::Instance();
         foreach($values as $key => $value){
-            $classDetails = $mapper->getClass(get_class() , $key);
+            $classDetails = $mapper->getClass(get_class($this) , $key);
             if (isset($value)){
                 if ($classDetails->className === 'Date'){
                     $dateTime = $value->format('Y-m-d');
@@ -102,7 +102,7 @@ class CreditCardSimpleType implements \JsonSerializable
         if(is_array($data) || is_object($data)) {
 			$mapper = \net\authorize\util\Mapper::Instance();
 			foreach($data AS $key => $value) {
-				$classDetails = $mapper->getClass(get_class() , $key);
+				$classDetails = $mapper->getClass(get_class($this) , $key);
 	 
 				if($classDetails !== NULL ) {
 					if ($classDetails->isArray) {

--- a/lib/net/authorize/api/contract/v1/CreditCardTrackType.php
+++ b/lib/net/authorize/api/contract/v1/CreditCardTrackType.php
@@ -74,7 +74,7 @@ class CreditCardTrackType implements \JsonSerializable
         });
         $mapper = \net\authorize\util\Mapper::Instance();
         foreach($values as $key => $value){
-            $classDetails = $mapper->getClass(get_class() , $key);
+            $classDetails = $mapper->getClass(get_class($this) , $key);
             if (isset($value)){
                 if ($classDetails->className === 'Date'){
                     $dateTime = $value->format('Y-m-d');
@@ -102,7 +102,7 @@ class CreditCardTrackType implements \JsonSerializable
         if(is_array($data) || is_object($data)) {
 			$mapper = \net\authorize\util\Mapper::Instance();
 			foreach($data AS $key => $value) {
-				$classDetails = $mapper->getClass(get_class() , $key);
+				$classDetails = $mapper->getClass(get_class($this) , $key);
 	 
 				if($classDetails !== NULL ) {
 					if ($classDetails->isArray) {

--- a/lib/net/authorize/api/contract/v1/CreditCardType.php
+++ b/lib/net/authorize/api/contract/v1/CreditCardType.php
@@ -182,7 +182,7 @@ class CreditCardType extends CreditCardSimpleType implements \JsonSerializable
         });
         $mapper = \net\authorize\util\Mapper::Instance();
         foreach($values as $key => $value){
-            $classDetails = $mapper->getClass(get_class() , $key);
+            $classDetails = $mapper->getClass(get_class($this) , $key);
             if (isset($value)){
                 if ($classDetails->className === 'Date'){
                     $dateTime = $value->format('Y-m-d');
@@ -210,7 +210,7 @@ class CreditCardType extends CreditCardSimpleType implements \JsonSerializable
         if(is_array($data) || is_object($data)) {
 			$mapper = \net\authorize\util\Mapper::Instance();
 			foreach($data AS $key => $value) {
-				$classDetails = $mapper->getClass(get_class() , $key);
+				$classDetails = $mapper->getClass(get_class($this) , $key);
 	 
 				if($classDetails !== NULL ) {
 					if ($classDetails->isArray) {

--- a/lib/net/authorize/api/contract/v1/CustomerAddressExType.php
+++ b/lib/net/authorize/api/contract/v1/CustomerAddressExType.php
@@ -47,7 +47,7 @@ class CustomerAddressExType extends CustomerAddressType implements \JsonSerializ
         });
         $mapper = \net\authorize\util\Mapper::Instance();
         foreach($values as $key => $value){
-            $classDetails = $mapper->getClass(get_class() , $key);
+            $classDetails = $mapper->getClass(get_class($this) , $key);
             if (isset($value)){
                 if ($classDetails->className === 'Date'){
                     $dateTime = $value->format('Y-m-d');
@@ -75,7 +75,7 @@ class CustomerAddressExType extends CustomerAddressType implements \JsonSerializ
         if(is_array($data) || is_object($data)) {
 			$mapper = \net\authorize\util\Mapper::Instance();
 			foreach($data AS $key => $value) {
-				$classDetails = $mapper->getClass(get_class() , $key);
+				$classDetails = $mapper->getClass(get_class($this) , $key);
 	 
 				if($classDetails !== NULL ) {
 					if ($classDetails->isArray) {

--- a/lib/net/authorize/api/contract/v1/CustomerAddressType.php
+++ b/lib/net/authorize/api/contract/v1/CustomerAddressType.php
@@ -101,7 +101,7 @@ class CustomerAddressType extends NameAndAddressType implements \JsonSerializabl
         });
         $mapper = \net\authorize\util\Mapper::Instance();
         foreach($values as $key => $value){
-            $classDetails = $mapper->getClass(get_class() , $key);
+            $classDetails = $mapper->getClass(get_class($this) , $key);
             if (isset($value)){
                 if ($classDetails->className === 'Date'){
                     $dateTime = $value->format('Y-m-d');
@@ -129,7 +129,7 @@ class CustomerAddressType extends NameAndAddressType implements \JsonSerializabl
         if(is_array($data) || is_object($data)) {
 			$mapper = \net\authorize\util\Mapper::Instance();
 			foreach($data AS $key => $value) {
-				$classDetails = $mapper->getClass(get_class() , $key);
+				$classDetails = $mapper->getClass(get_class($this) , $key);
 	 
 				if($classDetails !== NULL ) {
 					if ($classDetails->isArray) {

--- a/lib/net/authorize/api/contract/v1/CustomerDataType.php
+++ b/lib/net/authorize/api/contract/v1/CustomerDataType.php
@@ -155,7 +155,7 @@ class CustomerDataType implements \JsonSerializable
         });
         $mapper = \net\authorize\util\Mapper::Instance();
         foreach($values as $key => $value){
-            $classDetails = $mapper->getClass(get_class() , $key);
+            $classDetails = $mapper->getClass(get_class($this) , $key);
             if (isset($value)){
                 if ($classDetails->className === 'Date'){
                     $dateTime = $value->format('Y-m-d');
@@ -183,7 +183,7 @@ class CustomerDataType implements \JsonSerializable
         if(is_array($data) || is_object($data)) {
 			$mapper = \net\authorize\util\Mapper::Instance();
 			foreach($data AS $key => $value) {
-				$classDetails = $mapper->getClass(get_class() , $key);
+				$classDetails = $mapper->getClass(get_class($this) , $key);
 	 
 				if($classDetails !== NULL ) {
 					if ($classDetails->isArray) {

--- a/lib/net/authorize/api/contract/v1/CustomerPaymentProfileBaseType.php
+++ b/lib/net/authorize/api/contract/v1/CustomerPaymentProfileBaseType.php
@@ -74,7 +74,7 @@ class CustomerPaymentProfileBaseType implements \JsonSerializable
         });
         $mapper = \net\authorize\util\Mapper::Instance();
         foreach($values as $key => $value){
-            $classDetails = $mapper->getClass(get_class() , $key);
+            $classDetails = $mapper->getClass(get_class($this) , $key);
             if (isset($value)){
                 if ($classDetails->className === 'Date'){
                     $dateTime = $value->format('Y-m-d');
@@ -102,7 +102,7 @@ class CustomerPaymentProfileBaseType implements \JsonSerializable
         if(is_array($data) || is_object($data)) {
 			$mapper = \net\authorize\util\Mapper::Instance();
 			foreach($data AS $key => $value) {
-				$classDetails = $mapper->getClass(get_class() , $key);
+				$classDetails = $mapper->getClass(get_class($this) , $key);
 	 
 				if($classDetails !== NULL ) {
 					if ($classDetails->isArray) {

--- a/lib/net/authorize/api/contract/v1/CustomerPaymentProfileExType.php
+++ b/lib/net/authorize/api/contract/v1/CustomerPaymentProfileExType.php
@@ -47,7 +47,7 @@ class CustomerPaymentProfileExType extends CustomerPaymentProfileType implements
         });
         $mapper = \net\authorize\util\Mapper::Instance();
         foreach($values as $key => $value){
-            $classDetails = $mapper->getClass(get_class() , $key);
+            $classDetails = $mapper->getClass(get_class($this) , $key);
             if (isset($value)){
                 if ($classDetails->className === 'Date'){
                     $dateTime = $value->format('Y-m-d');
@@ -75,7 +75,7 @@ class CustomerPaymentProfileExType extends CustomerPaymentProfileType implements
         if(is_array($data) || is_object($data)) {
 			$mapper = \net\authorize\util\Mapper::Instance();
 			foreach($data AS $key => $value) {
-				$classDetails = $mapper->getClass(get_class() , $key);
+				$classDetails = $mapper->getClass(get_class($this) , $key);
 	 
 				if($classDetails !== NULL ) {
 					if ($classDetails->isArray) {

--- a/lib/net/authorize/api/contract/v1/CustomerPaymentProfileListItemType.php
+++ b/lib/net/authorize/api/contract/v1/CustomerPaymentProfileListItemType.php
@@ -209,7 +209,7 @@ class CustomerPaymentProfileListItemType implements \JsonSerializable
         });
         $mapper = \net\authorize\util\Mapper::Instance();
         foreach($values as $key => $value){
-            $classDetails = $mapper->getClass(get_class() , $key);
+            $classDetails = $mapper->getClass(get_class($this) , $key);
             if (isset($value)){
                 if ($classDetails->className === 'Date'){
                     $dateTime = $value->format('Y-m-d');
@@ -237,7 +237,7 @@ class CustomerPaymentProfileListItemType implements \JsonSerializable
         if(is_array($data) || is_object($data)) {
 			$mapper = \net\authorize\util\Mapper::Instance();
 			foreach($data AS $key => $value) {
-				$classDetails = $mapper->getClass(get_class() , $key);
+				$classDetails = $mapper->getClass(get_class($this) , $key);
 	 
 				if($classDetails !== NULL ) {
 					if ($classDetails->isArray) {

--- a/lib/net/authorize/api/contract/v1/CustomerPaymentProfileMaskedType.php
+++ b/lib/net/authorize/api/contract/v1/CustomerPaymentProfileMaskedType.php
@@ -298,7 +298,7 @@ class CustomerPaymentProfileMaskedType extends CustomerPaymentProfileBaseType im
         });
         $mapper = \net\authorize\util\Mapper::Instance();
         foreach($values as $key => $value){
-            $classDetails = $mapper->getClass(get_class() , $key);
+            $classDetails = $mapper->getClass(get_class($this) , $key);
             if (isset($value)){
                 if ($classDetails->className === 'Date'){
                     $dateTime = $value->format('Y-m-d');
@@ -326,7 +326,7 @@ class CustomerPaymentProfileMaskedType extends CustomerPaymentProfileBaseType im
         if(is_array($data) || is_object($data)) {
 			$mapper = \net\authorize\util\Mapper::Instance();
 			foreach($data AS $key => $value) {
-				$classDetails = $mapper->getClass(get_class() , $key);
+				$classDetails = $mapper->getClass(get_class($this) , $key);
 	 
 				if($classDetails !== NULL ) {
 					if ($classDetails->isArray) {

--- a/lib/net/authorize/api/contract/v1/CustomerPaymentProfileSortingType.php
+++ b/lib/net/authorize/api/contract/v1/CustomerPaymentProfileSortingType.php
@@ -74,7 +74,7 @@ class CustomerPaymentProfileSortingType implements \JsonSerializable
         });
         $mapper = \net\authorize\util\Mapper::Instance();
         foreach($values as $key => $value){
-            $classDetails = $mapper->getClass(get_class() , $key);
+            $classDetails = $mapper->getClass(get_class($this) , $key);
             if (isset($value)){
                 if ($classDetails->className === 'Date'){
                     $dateTime = $value->format('Y-m-d');
@@ -102,7 +102,7 @@ class CustomerPaymentProfileSortingType implements \JsonSerializable
         if(is_array($data) || is_object($data)) {
 			$mapper = \net\authorize\util\Mapper::Instance();
 			foreach($data AS $key => $value) {
-				$classDetails = $mapper->getClass(get_class() , $key);
+				$classDetails = $mapper->getClass(get_class($this) , $key);
 	 
 				if($classDetails !== NULL ) {
 					if ($classDetails->isArray) {

--- a/lib/net/authorize/api/contract/v1/CustomerPaymentProfileType.php
+++ b/lib/net/authorize/api/contract/v1/CustomerPaymentProfileType.php
@@ -157,7 +157,7 @@ class CustomerPaymentProfileType extends CustomerPaymentProfileBaseType implemen
         });
         $mapper = \net\authorize\util\Mapper::Instance();
         foreach($values as $key => $value){
-            $classDetails = $mapper->getClass(get_class() , $key);
+            $classDetails = $mapper->getClass(get_class($this) , $key);
             if (isset($value)){
                 if ($classDetails->className === 'Date'){
                     $dateTime = $value->format('Y-m-d');
@@ -185,7 +185,7 @@ class CustomerPaymentProfileType extends CustomerPaymentProfileBaseType implemen
         if(is_array($data) || is_object($data)) {
 			$mapper = \net\authorize\util\Mapper::Instance();
 			foreach($data AS $key => $value) {
-				$classDetails = $mapper->getClass(get_class() , $key);
+				$classDetails = $mapper->getClass(get_class($this) , $key);
 	 
 				if($classDetails !== NULL ) {
 					if ($classDetails->isArray) {

--- a/lib/net/authorize/api/contract/v1/CustomerProfileBaseType.php
+++ b/lib/net/authorize/api/contract/v1/CustomerProfileBaseType.php
@@ -101,7 +101,7 @@ class CustomerProfileBaseType implements \JsonSerializable
         });
         $mapper = \net\authorize\util\Mapper::Instance();
         foreach($values as $key => $value){
-            $classDetails = $mapper->getClass(get_class() , $key);
+            $classDetails = $mapper->getClass(get_class($this) , $key);
             if (isset($value)){
                 if ($classDetails->className === 'Date'){
                     $dateTime = $value->format('Y-m-d');
@@ -129,7 +129,7 @@ class CustomerProfileBaseType implements \JsonSerializable
         if(is_array($data) || is_object($data)) {
 			$mapper = \net\authorize\util\Mapper::Instance();
 			foreach($data AS $key => $value) {
-				$classDetails = $mapper->getClass(get_class() , $key);
+				$classDetails = $mapper->getClass(get_class($this) , $key);
 	 
 				if($classDetails !== NULL ) {
 					if ($classDetails->isArray) {

--- a/lib/net/authorize/api/contract/v1/CustomerProfileExType.php
+++ b/lib/net/authorize/api/contract/v1/CustomerProfileExType.php
@@ -47,7 +47,7 @@ class CustomerProfileExType extends CustomerProfileBaseType implements \JsonSeri
         });
         $mapper = \net\authorize\util\Mapper::Instance();
         foreach($values as $key => $value){
-            $classDetails = $mapper->getClass(get_class() , $key);
+            $classDetails = $mapper->getClass(get_class($this) , $key);
             if (isset($value)){
                 if ($classDetails->className === 'Date'){
                     $dateTime = $value->format('Y-m-d');
@@ -75,7 +75,7 @@ class CustomerProfileExType extends CustomerProfileBaseType implements \JsonSeri
         if(is_array($data) || is_object($data)) {
 			$mapper = \net\authorize\util\Mapper::Instance();
 			foreach($data AS $key => $value) {
-				$classDetails = $mapper->getClass(get_class() , $key);
+				$classDetails = $mapper->getClass(get_class($this) , $key);
 	 
 				if($classDetails !== NULL ) {
 					if ($classDetails->isArray) {

--- a/lib/net/authorize/api/contract/v1/CustomerProfileIdType.php
+++ b/lib/net/authorize/api/contract/v1/CustomerProfileIdType.php
@@ -101,7 +101,7 @@ class CustomerProfileIdType implements \JsonSerializable
         });
         $mapper = \net\authorize\util\Mapper::Instance();
         foreach($values as $key => $value){
-            $classDetails = $mapper->getClass(get_class() , $key);
+            $classDetails = $mapper->getClass(get_class($this) , $key);
             if (isset($value)){
                 if ($classDetails->className === 'Date'){
                     $dateTime = $value->format('Y-m-d');
@@ -129,7 +129,7 @@ class CustomerProfileIdType implements \JsonSerializable
         if(is_array($data) || is_object($data)) {
 			$mapper = \net\authorize\util\Mapper::Instance();
 			foreach($data AS $key => $value) {
-				$classDetails = $mapper->getClass(get_class() , $key);
+				$classDetails = $mapper->getClass(get_class($this) , $key);
 	 
 				if($classDetails !== NULL ) {
 					if ($classDetails->isArray) {

--- a/lib/net/authorize/api/contract/v1/CustomerProfileInfoExType.php
+++ b/lib/net/authorize/api/contract/v1/CustomerProfileInfoExType.php
@@ -47,7 +47,7 @@ class CustomerProfileInfoExType extends CustomerProfileExType implements \JsonSe
         });
         $mapper = \net\authorize\util\Mapper::Instance();
         foreach($values as $key => $value){
-            $classDetails = $mapper->getClass(get_class() , $key);
+            $classDetails = $mapper->getClass(get_class($this) , $key);
             if (isset($value)){
                 if ($classDetails->className === 'Date'){
                     $dateTime = $value->format('Y-m-d');
@@ -75,7 +75,7 @@ class CustomerProfileInfoExType extends CustomerProfileExType implements \JsonSe
         if(is_array($data) || is_object($data)) {
 			$mapper = \net\authorize\util\Mapper::Instance();
 			foreach($data AS $key => $value) {
-				$classDetails = $mapper->getClass(get_class() , $key);
+				$classDetails = $mapper->getClass(get_class($this) , $key);
 	 
 				if($classDetails !== NULL ) {
 					if ($classDetails->isArray) {

--- a/lib/net/authorize/api/contract/v1/CustomerProfileMaskedType.php
+++ b/lib/net/authorize/api/contract/v1/CustomerProfileMaskedType.php
@@ -172,7 +172,7 @@ class CustomerProfileMaskedType extends CustomerProfileExType implements \JsonSe
         });
         $mapper = \net\authorize\util\Mapper::Instance();
         foreach($values as $key => $value){
-            $classDetails = $mapper->getClass(get_class() , $key);
+            $classDetails = $mapper->getClass(get_class($this) , $key);
             if (isset($value)){
                 if ($classDetails->className === 'Date'){
                     $dateTime = $value->format('Y-m-d');
@@ -200,7 +200,7 @@ class CustomerProfileMaskedType extends CustomerProfileExType implements \JsonSe
         if(is_array($data) || is_object($data)) {
 			$mapper = \net\authorize\util\Mapper::Instance();
 			foreach($data AS $key => $value) {
-				$classDetails = $mapper->getClass(get_class() , $key);
+				$classDetails = $mapper->getClass(get_class($this) , $key);
 	 
 				if($classDetails !== NULL ) {
 					if ($classDetails->isArray) {

--- a/lib/net/authorize/api/contract/v1/CustomerProfilePaymentType.php
+++ b/lib/net/authorize/api/contract/v1/CustomerProfilePaymentType.php
@@ -128,7 +128,7 @@ class CustomerProfilePaymentType implements \JsonSerializable
         });
         $mapper = \net\authorize\util\Mapper::Instance();
         foreach($values as $key => $value){
-            $classDetails = $mapper->getClass(get_class() , $key);
+            $classDetails = $mapper->getClass(get_class($this) , $key);
             if (isset($value)){
                 if ($classDetails->className === 'Date'){
                     $dateTime = $value->format('Y-m-d');
@@ -156,7 +156,7 @@ class CustomerProfilePaymentType implements \JsonSerializable
         if(is_array($data) || is_object($data)) {
 			$mapper = \net\authorize\util\Mapper::Instance();
 			foreach($data AS $key => $value) {
-				$classDetails = $mapper->getClass(get_class() , $key);
+				$classDetails = $mapper->getClass(get_class($this) , $key);
 	 
 				if($classDetails !== NULL ) {
 					if ($classDetails->isArray) {

--- a/lib/net/authorize/api/contract/v1/CustomerProfileSummaryType.php
+++ b/lib/net/authorize/api/contract/v1/CustomerProfileSummaryType.php
@@ -155,7 +155,7 @@ class CustomerProfileSummaryType implements \JsonSerializable
         });
         $mapper = \net\authorize\util\Mapper::Instance();
         foreach($values as $key => $value){
-            $classDetails = $mapper->getClass(get_class() , $key);
+            $classDetails = $mapper->getClass(get_class($this) , $key);
             if (isset($value)){
                 if ($classDetails->className === 'Date'){
                     $dateTime = $value->format('Y-m-d');
@@ -183,7 +183,7 @@ class CustomerProfileSummaryType implements \JsonSerializable
         if(is_array($data) || is_object($data)) {
 			$mapper = \net\authorize\util\Mapper::Instance();
 			foreach($data AS $key => $value) {
-				$classDetails = $mapper->getClass(get_class() , $key);
+				$classDetails = $mapper->getClass(get_class($this) , $key);
 	 
 				if($classDetails !== NULL ) {
 					if ($classDetails->isArray) {

--- a/lib/net/authorize/api/contract/v1/CustomerProfileType.php
+++ b/lib/net/authorize/api/contract/v1/CustomerProfileType.php
@@ -172,7 +172,7 @@ class CustomerProfileType extends CustomerProfileBaseType implements \JsonSerial
         });
         $mapper = \net\authorize\util\Mapper::Instance();
         foreach($values as $key => $value){
-            $classDetails = $mapper->getClass(get_class() , $key);
+            $classDetails = $mapper->getClass(get_class($this) , $key);
             if (isset($value)){
                 if ($classDetails->className === 'Date'){
                     $dateTime = $value->format('Y-m-d');
@@ -200,7 +200,7 @@ class CustomerProfileType extends CustomerProfileBaseType implements \JsonSerial
         if(is_array($data) || is_object($data)) {
 			$mapper = \net\authorize\util\Mapper::Instance();
 			foreach($data AS $key => $value) {
-				$classDetails = $mapper->getClass(get_class() , $key);
+				$classDetails = $mapper->getClass(get_class($this) , $key);
 	 
 				if($classDetails !== NULL ) {
 					if ($classDetails->isArray) {

--- a/lib/net/authorize/api/contract/v1/CustomerType.php
+++ b/lib/net/authorize/api/contract/v1/CustomerType.php
@@ -209,7 +209,7 @@ class CustomerType implements \JsonSerializable
         });
         $mapper = \net\authorize\util\Mapper::Instance();
         foreach($values as $key => $value){
-            $classDetails = $mapper->getClass(get_class() , $key);
+            $classDetails = $mapper->getClass(get_class($this) , $key);
             if (isset($value)){
                 if ($classDetails->className === 'Date'){
                     $dateTime = $value->format('Y-m-d');
@@ -237,7 +237,7 @@ class CustomerType implements \JsonSerializable
         if(is_array($data) || is_object($data)) {
 			$mapper = \net\authorize\util\Mapper::Instance();
 			foreach($data AS $key => $value) {
-				$classDetails = $mapper->getClass(get_class() , $key);
+				$classDetails = $mapper->getClass(get_class($this) , $key);
 	 
 				if($classDetails !== NULL ) {
 					if ($classDetails->isArray) {

--- a/lib/net/authorize/api/contract/v1/DecryptPaymentDataRequest.php
+++ b/lib/net/authorize/api/contract/v1/DecryptPaymentDataRequest.php
@@ -71,7 +71,7 @@ class DecryptPaymentDataRequest extends ANetApiRequestType
         });
         $mapper = \net\authorize\util\Mapper::Instance();
         foreach($values as $key => $value){
-            $classDetails = $mapper->getClass(get_class() , $key);
+            $classDetails = $mapper->getClass(get_class($this) , $key);
             if (isset($value)){
                 if ($classDetails->className === 'Date'){
                     $dateTime = $value->format('Y-m-d');

--- a/lib/net/authorize/api/contract/v1/DecryptPaymentDataResponse.php
+++ b/lib/net/authorize/api/contract/v1/DecryptPaymentDataResponse.php
@@ -123,7 +123,7 @@ class DecryptPaymentDataResponse extends ANetApiResponseType
         if(is_array($data) || is_object($data)) {
 			$mapper = \net\authorize\util\Mapper::Instance();
 			foreach($data AS $key => $value) {
-				$classDetails = $mapper->getClass(get_class() , $key);
+				$classDetails = $mapper->getClass(get_class($this) , $key);
 	 
 				if($classDetails !== NULL ) {
 					if ($classDetails->isArray) {

--- a/lib/net/authorize/api/contract/v1/DeleteCustomerPaymentProfileRequest.php
+++ b/lib/net/authorize/api/contract/v1/DeleteCustomerPaymentProfileRequest.php
@@ -71,7 +71,7 @@ class DeleteCustomerPaymentProfileRequest extends ANetApiRequestType
         });
         $mapper = \net\authorize\util\Mapper::Instance();
         foreach($values as $key => $value){
-            $classDetails = $mapper->getClass(get_class() , $key);
+            $classDetails = $mapper->getClass(get_class($this) , $key);
             if (isset($value)){
                 if ($classDetails->className === 'Date'){
                     $dateTime = $value->format('Y-m-d');

--- a/lib/net/authorize/api/contract/v1/DeleteCustomerPaymentProfileResponse.php
+++ b/lib/net/authorize/api/contract/v1/DeleteCustomerPaymentProfileResponse.php
@@ -15,7 +15,7 @@ class DeleteCustomerPaymentProfileResponse extends ANetApiResponseType
         if(is_array($data) || is_object($data)) {
 			$mapper = \net\authorize\util\Mapper::Instance();
 			foreach($data AS $key => $value) {
-				$classDetails = $mapper->getClass(get_class() , $key);
+				$classDetails = $mapper->getClass(get_class($this) , $key);
 	 
 				if($classDetails !== NULL ) {
 					if ($classDetails->isArray) {

--- a/lib/net/authorize/api/contract/v1/DeleteCustomerProfileRequest.php
+++ b/lib/net/authorize/api/contract/v1/DeleteCustomerProfileRequest.php
@@ -44,7 +44,7 @@ class DeleteCustomerProfileRequest extends ANetApiRequestType
         });
         $mapper = \net\authorize\util\Mapper::Instance();
         foreach($values as $key => $value){
-            $classDetails = $mapper->getClass(get_class() , $key);
+            $classDetails = $mapper->getClass(get_class($this) , $key);
             if (isset($value)){
                 if ($classDetails->className === 'Date'){
                     $dateTime = $value->format('Y-m-d');

--- a/lib/net/authorize/api/contract/v1/DeleteCustomerProfileResponse.php
+++ b/lib/net/authorize/api/contract/v1/DeleteCustomerProfileResponse.php
@@ -15,7 +15,7 @@ class DeleteCustomerProfileResponse extends ANetApiResponseType
         if(is_array($data) || is_object($data)) {
 			$mapper = \net\authorize\util\Mapper::Instance();
 			foreach($data AS $key => $value) {
-				$classDetails = $mapper->getClass(get_class() , $key);
+				$classDetails = $mapper->getClass(get_class($this) , $key);
 	 
 				if($classDetails !== NULL ) {
 					if ($classDetails->isArray) {

--- a/lib/net/authorize/api/contract/v1/DeleteCustomerShippingAddressRequest.php
+++ b/lib/net/authorize/api/contract/v1/DeleteCustomerShippingAddressRequest.php
@@ -71,7 +71,7 @@ class DeleteCustomerShippingAddressRequest extends ANetApiRequestType
         });
         $mapper = \net\authorize\util\Mapper::Instance();
         foreach($values as $key => $value){
-            $classDetails = $mapper->getClass(get_class() , $key);
+            $classDetails = $mapper->getClass(get_class($this) , $key);
             if (isset($value)){
                 if ($classDetails->className === 'Date'){
                     $dateTime = $value->format('Y-m-d');

--- a/lib/net/authorize/api/contract/v1/DeleteCustomerShippingAddressResponse.php
+++ b/lib/net/authorize/api/contract/v1/DeleteCustomerShippingAddressResponse.php
@@ -15,7 +15,7 @@ class DeleteCustomerShippingAddressResponse extends ANetApiResponseType
         if(is_array($data) || is_object($data)) {
 			$mapper = \net\authorize\util\Mapper::Instance();
 			foreach($data AS $key => $value) {
-				$classDetails = $mapper->getClass(get_class() , $key);
+				$classDetails = $mapper->getClass(get_class($this) , $key);
 	 
 				if($classDetails !== NULL ) {
 					if ($classDetails->isArray) {

--- a/lib/net/authorize/api/contract/v1/DriversLicenseMaskedType.php
+++ b/lib/net/authorize/api/contract/v1/DriversLicenseMaskedType.php
@@ -101,7 +101,7 @@ class DriversLicenseMaskedType implements \JsonSerializable
         });
         $mapper = \net\authorize\util\Mapper::Instance();
         foreach($values as $key => $value){
-            $classDetails = $mapper->getClass(get_class() , $key);
+            $classDetails = $mapper->getClass(get_class($this) , $key);
             if (isset($value)){
                 if ($classDetails->className === 'Date'){
                     $dateTime = $value->format('Y-m-d');
@@ -129,7 +129,7 @@ class DriversLicenseMaskedType implements \JsonSerializable
         if(is_array($data) || is_object($data)) {
 			$mapper = \net\authorize\util\Mapper::Instance();
 			foreach($data AS $key => $value) {
-				$classDetails = $mapper->getClass(get_class() , $key);
+				$classDetails = $mapper->getClass(get_class($this) , $key);
 	 
 				if($classDetails !== NULL ) {
 					if ($classDetails->isArray) {

--- a/lib/net/authorize/api/contract/v1/DriversLicenseType.php
+++ b/lib/net/authorize/api/contract/v1/DriversLicenseType.php
@@ -101,7 +101,7 @@ class DriversLicenseType implements \JsonSerializable
         });
         $mapper = \net\authorize\util\Mapper::Instance();
         foreach($values as $key => $value){
-            $classDetails = $mapper->getClass(get_class() , $key);
+            $classDetails = $mapper->getClass(get_class($this) , $key);
             if (isset($value)){
                 if ($classDetails->className === 'Date'){
                     $dateTime = $value->format('Y-m-d');
@@ -129,7 +129,7 @@ class DriversLicenseType implements \JsonSerializable
         if(is_array($data) || is_object($data)) {
 			$mapper = \net\authorize\util\Mapper::Instance();
 			foreach($data AS $key => $value) {
-				$classDetails = $mapper->getClass(get_class() , $key);
+				$classDetails = $mapper->getClass(get_class($this) , $key);
 	 
 				if($classDetails !== NULL ) {
 					if ($classDetails->isArray) {

--- a/lib/net/authorize/api/contract/v1/EmailSettingsType.php
+++ b/lib/net/authorize/api/contract/v1/EmailSettingsType.php
@@ -47,7 +47,7 @@ class EmailSettingsType extends ArrayOfSettingType implements \JsonSerializable
         });
         $mapper = \net\authorize\util\Mapper::Instance();
         foreach($values as $key => $value){
-            $classDetails = $mapper->getClass(get_class() , $key);
+            $classDetails = $mapper->getClass(get_class($this) , $key);
             if (isset($value)){
                 if ($classDetails->className === 'Date'){
                     $dateTime = $value->format('Y-m-d');
@@ -75,7 +75,7 @@ class EmailSettingsType extends ArrayOfSettingType implements \JsonSerializable
         if(is_array($data) || is_object($data)) {
 			$mapper = \net\authorize\util\Mapper::Instance();
 			foreach($data AS $key => $value) {
-				$classDetails = $mapper->getClass(get_class() , $key);
+				$classDetails = $mapper->getClass(get_class($this) , $key);
 	 
 				if($classDetails !== NULL ) {
 					if ($classDetails->isArray) {

--- a/lib/net/authorize/api/contract/v1/EmvTagType.php
+++ b/lib/net/authorize/api/contract/v1/EmvTagType.php
@@ -101,7 +101,7 @@ class EmvTagType implements \JsonSerializable
         });
         $mapper = \net\authorize\util\Mapper::Instance();
         foreach($values as $key => $value){
-            $classDetails = $mapper->getClass(get_class() , $key);
+            $classDetails = $mapper->getClass(get_class($this) , $key);
             if (isset($value)){
                 if ($classDetails->className === 'Date'){
                     $dateTime = $value->format('Y-m-d');
@@ -129,7 +129,7 @@ class EmvTagType implements \JsonSerializable
         if(is_array($data) || is_object($data)) {
 			$mapper = \net\authorize\util\Mapper::Instance();
 			foreach($data AS $key => $value) {
-				$classDetails = $mapper->getClass(get_class() , $key);
+				$classDetails = $mapper->getClass(get_class($this) , $key);
 	 
 				if($classDetails !== NULL ) {
 					if ($classDetails->isArray) {

--- a/lib/net/authorize/api/contract/v1/EncryptedTrackDataType.php
+++ b/lib/net/authorize/api/contract/v1/EncryptedTrackDataType.php
@@ -47,7 +47,7 @@ class EncryptedTrackDataType implements \JsonSerializable
         });
         $mapper = \net\authorize\util\Mapper::Instance();
         foreach($values as $key => $value){
-            $classDetails = $mapper->getClass(get_class() , $key);
+            $classDetails = $mapper->getClass(get_class($this) , $key);
             if (isset($value)){
                 if ($classDetails->className === 'Date'){
                     $dateTime = $value->format('Y-m-d');
@@ -75,7 +75,7 @@ class EncryptedTrackDataType implements \JsonSerializable
         if(is_array($data) || is_object($data)) {
 			$mapper = \net\authorize\util\Mapper::Instance();
 			foreach($data AS $key => $value) {
-				$classDetails = $mapper->getClass(get_class() , $key);
+				$classDetails = $mapper->getClass(get_class($this) , $key);
 	 
 				if($classDetails !== NULL ) {
 					if ($classDetails->isArray) {

--- a/lib/net/authorize/api/contract/v1/ErrorResponse.php
+++ b/lib/net/authorize/api/contract/v1/ErrorResponse.php
@@ -15,7 +15,7 @@ class ErrorResponse extends ANetApiResponseType
         if(is_array($data) || is_object($data)) {
 			$mapper = \net\authorize\util\Mapper::Instance();
 			foreach($data AS $key => $value) {
-				$classDetails = $mapper->getClass(get_class() , $key);
+				$classDetails = $mapper->getClass(get_class($this) , $key);
 	 
 				if($classDetails !== NULL ) {
 					if ($classDetails->isArray) {

--- a/lib/net/authorize/api/contract/v1/ExtendedAmountType.php
+++ b/lib/net/authorize/api/contract/v1/ExtendedAmountType.php
@@ -101,7 +101,7 @@ class ExtendedAmountType implements \JsonSerializable
         });
         $mapper = \net\authorize\util\Mapper::Instance();
         foreach($values as $key => $value){
-            $classDetails = $mapper->getClass(get_class() , $key);
+            $classDetails = $mapper->getClass(get_class($this) , $key);
             if (isset($value)){
                 if ($classDetails->className === 'Date'){
                     $dateTime = $value->format('Y-m-d');
@@ -129,7 +129,7 @@ class ExtendedAmountType implements \JsonSerializable
         if(is_array($data) || is_object($data)) {
 			$mapper = \net\authorize\util\Mapper::Instance();
 			foreach($data AS $key => $value) {
-				$classDetails = $mapper->getClass(get_class() , $key);
+				$classDetails = $mapper->getClass(get_class($this) , $key);
 	 
 				if($classDetails !== NULL ) {
 					if ($classDetails->isArray) {

--- a/lib/net/authorize/api/contract/v1/FDSFilterType.php
+++ b/lib/net/authorize/api/contract/v1/FDSFilterType.php
@@ -74,7 +74,7 @@ class FDSFilterType implements \JsonSerializable
         });
         $mapper = \net\authorize\util\Mapper::Instance();
         foreach($values as $key => $value){
-            $classDetails = $mapper->getClass(get_class() , $key);
+            $classDetails = $mapper->getClass(get_class($this) , $key);
             if (isset($value)){
                 if ($classDetails->className === 'Date'){
                     $dateTime = $value->format('Y-m-d');
@@ -102,7 +102,7 @@ class FDSFilterType implements \JsonSerializable
         if(is_array($data) || is_object($data)) {
 			$mapper = \net\authorize\util\Mapper::Instance();
 			foreach($data AS $key => $value) {
-				$classDetails = $mapper->getClass(get_class() , $key);
+				$classDetails = $mapper->getClass(get_class($this) , $key);
 	 
 				if($classDetails !== NULL ) {
 					if ($classDetails->isArray) {

--- a/lib/net/authorize/api/contract/v1/FingerPrintType.php
+++ b/lib/net/authorize/api/contract/v1/FingerPrintType.php
@@ -155,7 +155,7 @@ class FingerPrintType implements \JsonSerializable
         });
         $mapper = \net\authorize\util\Mapper::Instance();
         foreach($values as $key => $value){
-            $classDetails = $mapper->getClass(get_class() , $key);
+            $classDetails = $mapper->getClass(get_class($this) , $key);
             if (isset($value)){
                 if ($classDetails->className === 'Date'){
                     $dateTime = $value->format('Y-m-d');
@@ -183,7 +183,7 @@ class FingerPrintType implements \JsonSerializable
         if(is_array($data) || is_object($data)) {
 			$mapper = \net\authorize\util\Mapper::Instance();
 			foreach($data AS $key => $value) {
-				$classDetails = $mapper->getClass(get_class() , $key);
+				$classDetails = $mapper->getClass(get_class($this) , $key);
 	 
 				if($classDetails !== NULL ) {
 					if ($classDetails->isArray) {

--- a/lib/net/authorize/api/contract/v1/FraudInformationType.php
+++ b/lib/net/authorize/api/contract/v1/FraudInformationType.php
@@ -108,7 +108,7 @@ class FraudInformationType implements \JsonSerializable
         });
         $mapper = \net\authorize\util\Mapper::Instance();
         foreach($values as $key => $value){
-            $classDetails = $mapper->getClass(get_class() , $key);
+            $classDetails = $mapper->getClass(get_class($this) , $key);
             if (isset($value)){
                 if ($classDetails->className === 'Date'){
                     $dateTime = $value->format('Y-m-d');
@@ -136,7 +136,7 @@ class FraudInformationType implements \JsonSerializable
         if(is_array($data) || is_object($data)) {
 			$mapper = \net\authorize\util\Mapper::Instance();
 			foreach($data AS $key => $value) {
-				$classDetails = $mapper->getClass(get_class() , $key);
+				$classDetails = $mapper->getClass(get_class($this) , $key);
 	 
 				if($classDetails !== NULL ) {
 					if ($classDetails->isArray) {

--- a/lib/net/authorize/api/contract/v1/GetAUJobDetailsRequest.php
+++ b/lib/net/authorize/api/contract/v1/GetAUJobDetailsRequest.php
@@ -98,7 +98,7 @@ class GetAUJobDetailsRequest extends ANetApiRequestType
         });
         $mapper = \net\authorize\util\Mapper::Instance();
         foreach($values as $key => $value){
-            $classDetails = $mapper->getClass(get_class() , $key);
+            $classDetails = $mapper->getClass(get_class($this) , $key);
             if (isset($value)){
                 if ($classDetails->className === 'Date'){
                     $dateTime = $value->format('Y-m-d');

--- a/lib/net/authorize/api/contract/v1/GetAUJobDetailsResponse.php
+++ b/lib/net/authorize/api/contract/v1/GetAUJobDetailsResponse.php
@@ -69,7 +69,7 @@ class GetAUJobDetailsResponse extends ANetApiResponseType
         if(is_array($data) || is_object($data)) {
 			$mapper = \net\authorize\util\Mapper::Instance();
 			foreach($data AS $key => $value) {
-				$classDetails = $mapper->getClass(get_class() , $key);
+				$classDetails = $mapper->getClass(get_class($this) , $key);
 	 
 				if($classDetails !== NULL ) {
 					if ($classDetails->isArray) {

--- a/lib/net/authorize/api/contract/v1/GetAUJobSummaryRequest.php
+++ b/lib/net/authorize/api/contract/v1/GetAUJobSummaryRequest.php
@@ -44,7 +44,7 @@ class GetAUJobSummaryRequest extends ANetApiRequestType
         });
         $mapper = \net\authorize\util\Mapper::Instance();
         foreach($values as $key => $value){
-            $classDetails = $mapper->getClass(get_class() , $key);
+            $classDetails = $mapper->getClass(get_class($this) , $key);
             if (isset($value)){
                 if ($classDetails->className === 'Date'){
                     $dateTime = $value->format('Y-m-d');

--- a/lib/net/authorize/api/contract/v1/GetAUJobSummaryResponse.php
+++ b/lib/net/authorize/api/contract/v1/GetAUJobSummaryResponse.php
@@ -76,7 +76,7 @@ class GetAUJobSummaryResponse extends ANetApiResponseType
         if(is_array($data) || is_object($data)) {
 			$mapper = \net\authorize\util\Mapper::Instance();
 			foreach($data AS $key => $value) {
-				$classDetails = $mapper->getClass(get_class() , $key);
+				$classDetails = $mapper->getClass(get_class($this) , $key);
 	 
 				if($classDetails !== NULL ) {
 					if ($classDetails->isArray) {

--- a/lib/net/authorize/api/contract/v1/GetBatchStatisticsRequest.php
+++ b/lib/net/authorize/api/contract/v1/GetBatchStatisticsRequest.php
@@ -44,7 +44,7 @@ class GetBatchStatisticsRequest extends ANetApiRequestType
         });
         $mapper = \net\authorize\util\Mapper::Instance();
         foreach($values as $key => $value){
-            $classDetails = $mapper->getClass(get_class() , $key);
+            $classDetails = $mapper->getClass(get_class($this) , $key);
             if (isset($value)){
                 if ($classDetails->className === 'Date'){
                     $dateTime = $value->format('Y-m-d');

--- a/lib/net/authorize/api/contract/v1/GetBatchStatisticsResponse.php
+++ b/lib/net/authorize/api/contract/v1/GetBatchStatisticsResponse.php
@@ -42,7 +42,7 @@ class GetBatchStatisticsResponse extends ANetApiResponseType
         if(is_array($data) || is_object($data)) {
 			$mapper = \net\authorize\util\Mapper::Instance();
 			foreach($data AS $key => $value) {
-				$classDetails = $mapper->getClass(get_class() , $key);
+				$classDetails = $mapper->getClass(get_class($this) , $key);
 	 
 				if($classDetails !== NULL ) {
 					if ($classDetails->isArray) {

--- a/lib/net/authorize/api/contract/v1/GetCustomerPaymentProfileListRequest.php
+++ b/lib/net/authorize/api/contract/v1/GetCustomerPaymentProfileListRequest.php
@@ -126,7 +126,7 @@ class GetCustomerPaymentProfileListRequest extends ANetApiRequestType
         });
         $mapper = \net\authorize\util\Mapper::Instance();
         foreach($values as $key => $value){
-            $classDetails = $mapper->getClass(get_class() , $key);
+            $classDetails = $mapper->getClass(get_class($this) , $key);
             if (isset($value)){
                 if ($classDetails->className === 'Date'){
                     $dateTime = $value->format('Y-m-d');

--- a/lib/net/authorize/api/contract/v1/GetCustomerPaymentProfileListResponse.php
+++ b/lib/net/authorize/api/contract/v1/GetCustomerPaymentProfileListResponse.php
@@ -106,7 +106,7 @@ class GetCustomerPaymentProfileListResponse extends ANetApiResponseType
         if(is_array($data) || is_object($data)) {
 			$mapper = \net\authorize\util\Mapper::Instance();
 			foreach($data AS $key => $value) {
-				$classDetails = $mapper->getClass(get_class() , $key);
+				$classDetails = $mapper->getClass(get_class($this) , $key);
 	 
 				if($classDetails !== NULL ) {
 					if ($classDetails->isArray) {

--- a/lib/net/authorize/api/contract/v1/GetCustomerPaymentProfileRequest.php
+++ b/lib/net/authorize/api/contract/v1/GetCustomerPaymentProfileRequest.php
@@ -125,7 +125,7 @@ class GetCustomerPaymentProfileRequest extends ANetApiRequestType
         });
         $mapper = \net\authorize\util\Mapper::Instance();
         foreach($values as $key => $value){
-            $classDetails = $mapper->getClass(get_class() , $key);
+            $classDetails = $mapper->getClass(get_class($this) , $key);
             if (isset($value)){
                 if ($classDetails->className === 'Date'){
                     $dateTime = $value->format('Y-m-d');

--- a/lib/net/authorize/api/contract/v1/GetCustomerPaymentProfileResponse.php
+++ b/lib/net/authorize/api/contract/v1/GetCustomerPaymentProfileResponse.php
@@ -44,7 +44,7 @@ class GetCustomerPaymentProfileResponse extends ANetApiResponseType
         if(is_array($data) || is_object($data)) {
 			$mapper = \net\authorize\util\Mapper::Instance();
 			foreach($data AS $key => $value) {
-				$classDetails = $mapper->getClass(get_class() , $key);
+				$classDetails = $mapper->getClass(get_class($this) , $key);
 	 
 				if($classDetails !== NULL ) {
 					if ($classDetails->isArray) {

--- a/lib/net/authorize/api/contract/v1/GetCustomerProfileIdsRequest.php
+++ b/lib/net/authorize/api/contract/v1/GetCustomerProfileIdsRequest.php
@@ -17,7 +17,7 @@ class GetCustomerProfileIdsRequest extends ANetApiRequestType
         });
         $mapper = \net\authorize\util\Mapper::Instance();
         foreach($values as $key => $value){
-            $classDetails = $mapper->getClass(get_class() , $key);
+            $classDetails = $mapper->getClass(get_class($this) , $key);
             if (isset($value)){
                 if ($classDetails->className === 'Date'){
                     $dateTime = $value->format('Y-m-d');

--- a/lib/net/authorize/api/contract/v1/GetCustomerProfileIdsResponse.php
+++ b/lib/net/authorize/api/contract/v1/GetCustomerProfileIdsResponse.php
@@ -76,7 +76,7 @@ class GetCustomerProfileIdsResponse extends ANetApiResponseType
         if(is_array($data) || is_object($data)) {
 			$mapper = \net\authorize\util\Mapper::Instance();
 			foreach($data AS $key => $value) {
-				$classDetails = $mapper->getClass(get_class() , $key);
+				$classDetails = $mapper->getClass(get_class($this) , $key);
 	 
 				if($classDetails !== NULL ) {
 					if ($classDetails->isArray) {

--- a/lib/net/authorize/api/contract/v1/GetCustomerProfileRequest.php
+++ b/lib/net/authorize/api/contract/v1/GetCustomerProfileRequest.php
@@ -152,7 +152,7 @@ class GetCustomerProfileRequest extends ANetApiRequestType
         });
         $mapper = \net\authorize\util\Mapper::Instance();
         foreach($values as $key => $value){
-            $classDetails = $mapper->getClass(get_class() , $key);
+            $classDetails = $mapper->getClass(get_class($this) , $key);
             if (isset($value)){
                 if ($classDetails->className === 'Date'){
                     $dateTime = $value->format('Y-m-d');

--- a/lib/net/authorize/api/contract/v1/GetCustomerProfileResponse.php
+++ b/lib/net/authorize/api/contract/v1/GetCustomerProfileResponse.php
@@ -103,7 +103,7 @@ class GetCustomerProfileResponse extends ANetApiResponseType
         if(is_array($data) || is_object($data)) {
 			$mapper = \net\authorize\util\Mapper::Instance();
 			foreach($data AS $key => $value) {
-				$classDetails = $mapper->getClass(get_class() , $key);
+				$classDetails = $mapper->getClass(get_class($this) , $key);
 	 
 				if($classDetails !== NULL ) {
 					if ($classDetails->isArray) {

--- a/lib/net/authorize/api/contract/v1/GetCustomerShippingAddressRequest.php
+++ b/lib/net/authorize/api/contract/v1/GetCustomerShippingAddressRequest.php
@@ -71,7 +71,7 @@ class GetCustomerShippingAddressRequest extends ANetApiRequestType
         });
         $mapper = \net\authorize\util\Mapper::Instance();
         foreach($values as $key => $value){
-            $classDetails = $mapper->getClass(get_class() , $key);
+            $classDetails = $mapper->getClass(get_class($this) , $key);
             if (isset($value)){
                 if ($classDetails->className === 'Date'){
                     $dateTime = $value->format('Y-m-d');

--- a/lib/net/authorize/api/contract/v1/GetCustomerShippingAddressResponse.php
+++ b/lib/net/authorize/api/contract/v1/GetCustomerShippingAddressResponse.php
@@ -130,7 +130,7 @@ class GetCustomerShippingAddressResponse extends ANetApiResponseType
         if(is_array($data) || is_object($data)) {
 			$mapper = \net\authorize\util\Mapper::Instance();
 			foreach($data AS $key => $value) {
-				$classDetails = $mapper->getClass(get_class() , $key);
+				$classDetails = $mapper->getClass(get_class($this) , $key);
 	 
 				if($classDetails !== NULL ) {
 					if ($classDetails->isArray) {

--- a/lib/net/authorize/api/contract/v1/GetHostedPaymentPageRequest.php
+++ b/lib/net/authorize/api/contract/v1/GetHostedPaymentPageRequest.php
@@ -148,7 +148,7 @@ class GetHostedPaymentPageRequest extends ANetApiRequestType
         });
         $mapper = \net\authorize\util\Mapper::Instance();
         foreach($values as $key => $value){
-            $classDetails = $mapper->getClass(get_class() , $key);
+            $classDetails = $mapper->getClass(get_class($this) , $key);
             if (isset($value)){
                 if ($classDetails->className === 'Date'){
                     $dateTime = $value->format('Y-m-d');

--- a/lib/net/authorize/api/contract/v1/GetHostedPaymentPageResponse.php
+++ b/lib/net/authorize/api/contract/v1/GetHostedPaymentPageResponse.php
@@ -42,7 +42,7 @@ class GetHostedPaymentPageResponse extends ANetApiResponseType
         if(is_array($data) || is_object($data)) {
 			$mapper = \net\authorize\util\Mapper::Instance();
 			foreach($data AS $key => $value) {
-				$classDetails = $mapper->getClass(get_class() , $key);
+				$classDetails = $mapper->getClass(get_class($this) , $key);
 	 
 				if($classDetails !== NULL ) {
 					if ($classDetails->isArray) {

--- a/lib/net/authorize/api/contract/v1/GetHostedProfilePageRequest.php
+++ b/lib/net/authorize/api/contract/v1/GetHostedProfilePageRequest.php
@@ -147,7 +147,7 @@ class GetHostedProfilePageRequest extends ANetApiRequestType
         });
         $mapper = \net\authorize\util\Mapper::Instance();
         foreach($values as $key => $value){
-            $classDetails = $mapper->getClass(get_class() , $key);
+            $classDetails = $mapper->getClass(get_class($this) , $key);
             if (isset($value)){
                 if ($classDetails->className === 'Date'){
                     $dateTime = $value->format('Y-m-d');

--- a/lib/net/authorize/api/contract/v1/GetHostedProfilePageResponse.php
+++ b/lib/net/authorize/api/contract/v1/GetHostedProfilePageResponse.php
@@ -42,7 +42,7 @@ class GetHostedProfilePageResponse extends ANetApiResponseType
         if(is_array($data) || is_object($data)) {
 			$mapper = \net\authorize\util\Mapper::Instance();
 			foreach($data AS $key => $value) {
-				$classDetails = $mapper->getClass(get_class() , $key);
+				$classDetails = $mapper->getClass(get_class($this) , $key);
 	 
 				if($classDetails !== NULL ) {
 					if ($classDetails->isArray) {

--- a/lib/net/authorize/api/contract/v1/GetMerchantDetailsRequest.php
+++ b/lib/net/authorize/api/contract/v1/GetMerchantDetailsRequest.php
@@ -17,7 +17,7 @@ class GetMerchantDetailsRequest extends ANetApiRequestType
         });
         $mapper = \net\authorize\util\Mapper::Instance();
         foreach($values as $key => $value){
-            $classDetails = $mapper->getClass(get_class() , $key);
+            $classDetails = $mapper->getClass(get_class($this) , $key);
             if (isset($value)){
                 if ($classDetails->className === 'Date'){
                     $dateTime = $value->format('Y-m-d');

--- a/lib/net/authorize/api/contract/v1/GetMerchantDetailsResponse.php
+++ b/lib/net/authorize/api/contract/v1/GetMerchantDetailsResponse.php
@@ -544,7 +544,7 @@ class GetMerchantDetailsResponse extends ANetApiResponseType
         if(is_array($data) || is_object($data)) {
 			$mapper = \net\authorize\util\Mapper::Instance();
 			foreach($data AS $key => $value) {
-				$classDetails = $mapper->getClass(get_class() , $key);
+				$classDetails = $mapper->getClass(get_class($this) , $key);
 	 
 				if($classDetails !== NULL ) {
 					if ($classDetails->isArray) {

--- a/lib/net/authorize/api/contract/v1/GetSettledBatchListRequest.php
+++ b/lib/net/authorize/api/contract/v1/GetSettledBatchListRequest.php
@@ -98,7 +98,7 @@ class GetSettledBatchListRequest extends ANetApiRequestType
         });
         $mapper = \net\authorize\util\Mapper::Instance();
         foreach($values as $key => $value){
-            $classDetails = $mapper->getClass(get_class() , $key);
+            $classDetails = $mapper->getClass(get_class($this) , $key);
             if (isset($value)){
                 if ($classDetails->className === 'Date'){
                     $dateTime = $value->format('Y-m-d');

--- a/lib/net/authorize/api/contract/v1/GetSettledBatchListResponse.php
+++ b/lib/net/authorize/api/contract/v1/GetSettledBatchListResponse.php
@@ -76,7 +76,7 @@ class GetSettledBatchListResponse extends ANetApiResponseType
         if(is_array($data) || is_object($data)) {
 			$mapper = \net\authorize\util\Mapper::Instance();
 			foreach($data AS $key => $value) {
-				$classDetails = $mapper->getClass(get_class() , $key);
+				$classDetails = $mapper->getClass(get_class($this) , $key);
 	 
 				if($classDetails !== NULL ) {
 					if ($classDetails->isArray) {

--- a/lib/net/authorize/api/contract/v1/GetTransactionDetailsRequest.php
+++ b/lib/net/authorize/api/contract/v1/GetTransactionDetailsRequest.php
@@ -44,7 +44,7 @@ class GetTransactionDetailsRequest extends ANetApiRequestType
         });
         $mapper = \net\authorize\util\Mapper::Instance();
         foreach($values as $key => $value){
-            $classDetails = $mapper->getClass(get_class() , $key);
+            $classDetails = $mapper->getClass(get_class($this) , $key);
             if (isset($value)){
                 if ($classDetails->className === 'Date'){
                     $dateTime = $value->format('Y-m-d');

--- a/lib/net/authorize/api/contract/v1/GetTransactionDetailsResponse.php
+++ b/lib/net/authorize/api/contract/v1/GetTransactionDetailsResponse.php
@@ -96,7 +96,7 @@ class GetTransactionDetailsResponse extends ANetApiResponseType
         if(is_array($data) || is_object($data)) {
 			$mapper = \net\authorize\util\Mapper::Instance();
 			foreach($data AS $key => $value) {
-				$classDetails = $mapper->getClass(get_class() , $key);
+				$classDetails = $mapper->getClass(get_class($this) , $key);
 	 
 				if($classDetails !== NULL ) {
 					if ($classDetails->isArray) {

--- a/lib/net/authorize/api/contract/v1/GetTransactionListForCustomerRequest.php
+++ b/lib/net/authorize/api/contract/v1/GetTransactionListForCustomerRequest.php
@@ -125,7 +125,7 @@ class GetTransactionListForCustomerRequest extends ANetApiRequestType
         });
         $mapper = \net\authorize\util\Mapper::Instance();
         foreach($values as $key => $value){
-            $classDetails = $mapper->getClass(get_class() , $key);
+            $classDetails = $mapper->getClass(get_class($this) , $key);
             if (isset($value)){
                 if ($classDetails->className === 'Date'){
                     $dateTime = $value->format('Y-m-d');

--- a/lib/net/authorize/api/contract/v1/GetTransactionListRequest.php
+++ b/lib/net/authorize/api/contract/v1/GetTransactionListRequest.php
@@ -98,7 +98,7 @@ class GetTransactionListRequest extends ANetApiRequestType
         });
         $mapper = \net\authorize\util\Mapper::Instance();
         foreach($values as $key => $value){
-            $classDetails = $mapper->getClass(get_class() , $key);
+            $classDetails = $mapper->getClass(get_class($this) , $key);
             if (isset($value)){
                 if ($classDetails->className === 'Date'){
                     $dateTime = $value->format('Y-m-d');

--- a/lib/net/authorize/api/contract/v1/GetTransactionListResponse.php
+++ b/lib/net/authorize/api/contract/v1/GetTransactionListResponse.php
@@ -103,7 +103,7 @@ class GetTransactionListResponse extends ANetApiResponseType
         if(is_array($data) || is_object($data)) {
 			$mapper = \net\authorize\util\Mapper::Instance();
 			foreach($data AS $key => $value) {
-				$classDetails = $mapper->getClass(get_class() , $key);
+				$classDetails = $mapper->getClass(get_class($this) , $key);
 	 
 				if($classDetails !== NULL ) {
 					if ($classDetails->isArray) {

--- a/lib/net/authorize/api/contract/v1/GetUnsettledTransactionListRequest.php
+++ b/lib/net/authorize/api/contract/v1/GetUnsettledTransactionListRequest.php
@@ -98,7 +98,7 @@ class GetUnsettledTransactionListRequest extends ANetApiRequestType
         });
         $mapper = \net\authorize\util\Mapper::Instance();
         foreach($values as $key => $value){
-            $classDetails = $mapper->getClass(get_class() , $key);
+            $classDetails = $mapper->getClass(get_class($this) , $key);
             if (isset($value)){
                 if ($classDetails->className === 'Date'){
                     $dateTime = $value->format('Y-m-d');

--- a/lib/net/authorize/api/contract/v1/GetUnsettledTransactionListResponse.php
+++ b/lib/net/authorize/api/contract/v1/GetUnsettledTransactionListResponse.php
@@ -103,7 +103,7 @@ class GetUnsettledTransactionListResponse extends ANetApiResponseType
         if(is_array($data) || is_object($data)) {
 			$mapper = \net\authorize\util\Mapper::Instance();
 			foreach($data AS $key => $value) {
-				$classDetails = $mapper->getClass(get_class() , $key);
+				$classDetails = $mapper->getClass(get_class($this) , $key);
 	 
 				if($classDetails !== NULL ) {
 					if ($classDetails->isArray) {

--- a/lib/net/authorize/api/contract/v1/HeldTransactionRequestType.php
+++ b/lib/net/authorize/api/contract/v1/HeldTransactionRequestType.php
@@ -74,7 +74,7 @@ class HeldTransactionRequestType implements \JsonSerializable
         });
         $mapper = \net\authorize\util\Mapper::Instance();
         foreach($values as $key => $value){
-            $classDetails = $mapper->getClass(get_class() , $key);
+            $classDetails = $mapper->getClass(get_class($this) , $key);
             if (isset($value)){
                 if ($classDetails->className === 'Date'){
                     $dateTime = $value->format('Y-m-d');
@@ -102,7 +102,7 @@ class HeldTransactionRequestType implements \JsonSerializable
         if(is_array($data) || is_object($data)) {
 			$mapper = \net\authorize\util\Mapper::Instance();
 			foreach($data AS $key => $value) {
-				$classDetails = $mapper->getClass(get_class() , $key);
+				$classDetails = $mapper->getClass(get_class($this) , $key);
 	 
 				if($classDetails !== NULL ) {
 					if ($classDetails->isArray) {

--- a/lib/net/authorize/api/contract/v1/ImpersonationAuthenticationType.php
+++ b/lib/net/authorize/api/contract/v1/ImpersonationAuthenticationType.php
@@ -74,7 +74,7 @@ class ImpersonationAuthenticationType implements \JsonSerializable
         });
         $mapper = \net\authorize\util\Mapper::Instance();
         foreach($values as $key => $value){
-            $classDetails = $mapper->getClass(get_class() , $key);
+            $classDetails = $mapper->getClass(get_class($this) , $key);
             if (isset($value)){
                 if ($classDetails->className === 'Date'){
                     $dateTime = $value->format('Y-m-d');
@@ -102,7 +102,7 @@ class ImpersonationAuthenticationType implements \JsonSerializable
         if(is_array($data) || is_object($data)) {
 			$mapper = \net\authorize\util\Mapper::Instance();
 			foreach($data AS $key => $value) {
-				$classDetails = $mapper->getClass(get_class() , $key);
+				$classDetails = $mapper->getClass(get_class($this) , $key);
 	 
 				if($classDetails !== NULL ) {
 					if ($classDetails->isArray) {

--- a/lib/net/authorize/api/contract/v1/IsAliveRequest.php
+++ b/lib/net/authorize/api/contract/v1/IsAliveRequest.php
@@ -44,7 +44,7 @@ class IsAliveRequest
         });
         $mapper = \net\authorize\util\Mapper::Instance();
         foreach($values as $key => $value){
-            $classDetails = $mapper->getClass(get_class() , $key);
+            $classDetails = $mapper->getClass(get_class($this) , $key);
             if (isset($value)){
                 if ($classDetails->className === 'Date'){
                     $dateTime = $value->format('Y-m-d');

--- a/lib/net/authorize/api/contract/v1/IsAliveResponse.php
+++ b/lib/net/authorize/api/contract/v1/IsAliveResponse.php
@@ -15,7 +15,7 @@ class IsAliveResponse extends ANetApiResponseType
         if(is_array($data) || is_object($data)) {
 			$mapper = \net\authorize\util\Mapper::Instance();
 			foreach($data AS $key => $value) {
-				$classDetails = $mapper->getClass(get_class() , $key);
+				$classDetails = $mapper->getClass(get_class($this) , $key);
 	 
 				if($classDetails !== NULL ) {
 					if ($classDetails->isArray) {

--- a/lib/net/authorize/api/contract/v1/KeyBlockType.php
+++ b/lib/net/authorize/api/contract/v1/KeyBlockType.php
@@ -47,7 +47,7 @@ class KeyBlockType implements \JsonSerializable
         });
         $mapper = \net\authorize\util\Mapper::Instance();
         foreach($values as $key => $value){
-            $classDetails = $mapper->getClass(get_class() , $key);
+            $classDetails = $mapper->getClass(get_class($this) , $key);
             if (isset($value)){
                 if ($classDetails->className === 'Date'){
                     $dateTime = $value->format('Y-m-d');
@@ -75,7 +75,7 @@ class KeyBlockType implements \JsonSerializable
         if(is_array($data) || is_object($data)) {
 			$mapper = \net\authorize\util\Mapper::Instance();
 			foreach($data AS $key => $value) {
-				$classDetails = $mapper->getClass(get_class() , $key);
+				$classDetails = $mapper->getClass(get_class($this) , $key);
 	 
 				if($classDetails !== NULL ) {
 					if ($classDetails->isArray) {

--- a/lib/net/authorize/api/contract/v1/KeyManagementSchemeType.php
+++ b/lib/net/authorize/api/contract/v1/KeyManagementSchemeType.php
@@ -48,7 +48,7 @@ class KeyManagementSchemeType implements \JsonSerializable
         });
         $mapper = \net\authorize\util\Mapper::Instance();
         foreach($values as $key => $value){
-            $classDetails = $mapper->getClass(get_class() , $key);
+            $classDetails = $mapper->getClass(get_class($this) , $key);
             if (isset($value)){
                 if ($classDetails->className === 'Date'){
                     $dateTime = $value->format('Y-m-d');
@@ -76,7 +76,7 @@ class KeyManagementSchemeType implements \JsonSerializable
         if(is_array($data) || is_object($data)) {
 			$mapper = \net\authorize\util\Mapper::Instance();
 			foreach($data AS $key => $value) {
-				$classDetails = $mapper->getClass(get_class() , $key);
+				$classDetails = $mapper->getClass(get_class($this) , $key);
 	 
 				if($classDetails !== NULL ) {
 					if ($classDetails->isArray) {

--- a/lib/net/authorize/api/contract/v1/KeyManagementSchemeType/DUKPTAType.php
+++ b/lib/net/authorize/api/contract/v1/KeyManagementSchemeType/DUKPTAType.php
@@ -140,7 +140,7 @@ class DUKPTAType implements \JsonSerializable
         });
         $mapper = \net\authorize\util\Mapper::Instance();
         foreach($values as $key => $value){
-            $classDetails = $mapper->getClass(get_class() , $key);
+            $classDetails = $mapper->getClass(get_class($this) , $key);
             if (isset($value)){
                 if ($classDetails->className === 'Date'){
                     $dateTime = $value->format('Y-m-d');
@@ -168,7 +168,7 @@ class DUKPTAType implements \JsonSerializable
         if(is_array($data) || is_object($data)) {
 			$mapper = \net\authorize\util\Mapper::Instance();
 			foreach($data AS $key => $value) {
-				$classDetails = $mapper->getClass(get_class() , $key);
+				$classDetails = $mapper->getClass(get_class($this) , $key);
 	 
 				if($classDetails !== NULL ) {
 					if ($classDetails->isArray) {

--- a/lib/net/authorize/api/contract/v1/KeyManagementSchemeType/DUKPTAType/DeviceInfoAType.php
+++ b/lib/net/authorize/api/contract/v1/KeyManagementSchemeType/DUKPTAType/DeviceInfoAType.php
@@ -44,7 +44,7 @@ class DeviceInfoAType implements \JsonSerializable
         });
         $mapper = \net\authorize\util\Mapper::Instance();
         foreach($values as $key => $value){
-            $classDetails = $mapper->getClass(get_class() , $key);
+            $classDetails = $mapper->getClass(get_class($this) , $key);
             if (isset($value)){
                 if ($classDetails->className === 'Date'){
                     $dateTime = $value->format('Y-m-d');
@@ -72,7 +72,7 @@ class DeviceInfoAType implements \JsonSerializable
         if(is_array($data) || is_object($data)) {
 			$mapper = \net\authorize\util\Mapper::Instance();
 			foreach($data AS $key => $value) {
-				$classDetails = $mapper->getClass(get_class() , $key);
+				$classDetails = $mapper->getClass(get_class($this) , $key);
 	 
 				if($classDetails !== NULL ) {
 					if ($classDetails->isArray) {

--- a/lib/net/authorize/api/contract/v1/KeyManagementSchemeType/DUKPTAType/EncryptedDataAType.php
+++ b/lib/net/authorize/api/contract/v1/KeyManagementSchemeType/DUKPTAType/EncryptedDataAType.php
@@ -44,7 +44,7 @@ class EncryptedDataAType implements \JsonSerializable
         });
         $mapper = \net\authorize\util\Mapper::Instance();
         foreach($values as $key => $value){
-            $classDetails = $mapper->getClass(get_class() , $key);
+            $classDetails = $mapper->getClass(get_class($this) , $key);
             if (isset($value)){
                 if ($classDetails->className === 'Date'){
                     $dateTime = $value->format('Y-m-d');
@@ -72,7 +72,7 @@ class EncryptedDataAType implements \JsonSerializable
         if(is_array($data) || is_object($data)) {
 			$mapper = \net\authorize\util\Mapper::Instance();
 			foreach($data AS $key => $value) {
-				$classDetails = $mapper->getClass(get_class() , $key);
+				$classDetails = $mapper->getClass(get_class($this) , $key);
 	 
 				if($classDetails !== NULL ) {
 					if ($classDetails->isArray) {

--- a/lib/net/authorize/api/contract/v1/KeyManagementSchemeType/DUKPTAType/ModeAType.php
+++ b/lib/net/authorize/api/contract/v1/KeyManagementSchemeType/DUKPTAType/ModeAType.php
@@ -71,7 +71,7 @@ class ModeAType implements \JsonSerializable
         });
         $mapper = \net\authorize\util\Mapper::Instance();
         foreach($values as $key => $value){
-            $classDetails = $mapper->getClass(get_class() , $key);
+            $classDetails = $mapper->getClass(get_class($this) , $key);
             if (isset($value)){
                 if ($classDetails->className === 'Date'){
                     $dateTime = $value->format('Y-m-d');
@@ -99,7 +99,7 @@ class ModeAType implements \JsonSerializable
         if(is_array($data) || is_object($data)) {
 			$mapper = \net\authorize\util\Mapper::Instance();
 			foreach($data AS $key => $value) {
-				$classDetails = $mapper->getClass(get_class() , $key);
+				$classDetails = $mapper->getClass(get_class($this) , $key);
 	 
 				if($classDetails !== NULL ) {
 					if ($classDetails->isArray) {

--- a/lib/net/authorize/api/contract/v1/KeyValueType.php
+++ b/lib/net/authorize/api/contract/v1/KeyValueType.php
@@ -101,7 +101,7 @@ class KeyValueType implements \JsonSerializable
         });
         $mapper = \net\authorize\util\Mapper::Instance();
         foreach($values as $key => $value){
-            $classDetails = $mapper->getClass(get_class() , $key);
+            $classDetails = $mapper->getClass(get_class($this) , $key);
             if (isset($value)){
                 if ($classDetails->className === 'Date'){
                     $dateTime = $value->format('Y-m-d');
@@ -129,7 +129,7 @@ class KeyValueType implements \JsonSerializable
         if(is_array($data) || is_object($data)) {
 			$mapper = \net\authorize\util\Mapper::Instance();
 			foreach($data AS $key => $value) {
-				$classDetails = $mapper->getClass(get_class() , $key);
+				$classDetails = $mapper->getClass(get_class($this) , $key);
 	 
 				if($classDetails !== NULL ) {
 					if ($classDetails->isArray) {

--- a/lib/net/authorize/api/contract/v1/LineItemType.php
+++ b/lib/net/authorize/api/contract/v1/LineItemType.php
@@ -722,7 +722,7 @@ class LineItemType implements \JsonSerializable
         });
         $mapper = \net\authorize\util\Mapper::Instance();
         foreach($values as $key => $value){
-            $classDetails = $mapper->getClass(get_class() , $key);
+            $classDetails = $mapper->getClass(get_class($this) , $key);
             if (isset($value)){
                 if ($classDetails->className === 'Date'){
                     $dateTime = $value->format('Y-m-d');
@@ -750,7 +750,7 @@ class LineItemType implements \JsonSerializable
         if(is_array($data) || is_object($data)) {
 			$mapper = \net\authorize\util\Mapper::Instance();
 			foreach($data AS $key => $value) {
-				$classDetails = $mapper->getClass(get_class() , $key);
+				$classDetails = $mapper->getClass(get_class($this) , $key);
 	 
 				if($classDetails !== NULL ) {
 					if ($classDetails->isArray) {

--- a/lib/net/authorize/api/contract/v1/ListOfAUDetailsType.php
+++ b/lib/net/authorize/api/contract/v1/ListOfAUDetailsType.php
@@ -142,7 +142,7 @@ class ListOfAUDetailsType implements \JsonSerializable
         });
         $mapper = \net\authorize\util\Mapper::Instance();
         foreach($values as $key => $value){
-            $classDetails = $mapper->getClass(get_class() , $key);
+            $classDetails = $mapper->getClass(get_class($this) , $key);
             if (isset($value)){
                 if ($classDetails->className === 'Date'){
                     $dateTime = $value->format('Y-m-d');
@@ -170,7 +170,7 @@ class ListOfAUDetailsType implements \JsonSerializable
         if(is_array($data) || is_object($data)) {
 			$mapper = \net\authorize\util\Mapper::Instance();
 			foreach($data AS $key => $value) {
-				$classDetails = $mapper->getClass(get_class() , $key);
+				$classDetails = $mapper->getClass(get_class($this) , $key);
 	 
 				if($classDetails !== NULL ) {
 					if ($classDetails->isArray) {

--- a/lib/net/authorize/api/contract/v1/LogoutRequest.php
+++ b/lib/net/authorize/api/contract/v1/LogoutRequest.php
@@ -17,7 +17,7 @@ class LogoutRequest extends ANetApiRequestType
         });
         $mapper = \net\authorize\util\Mapper::Instance();
         foreach($values as $key => $value){
-            $classDetails = $mapper->getClass(get_class() , $key);
+            $classDetails = $mapper->getClass(get_class($this) , $key);
             if (isset($value)){
                 if ($classDetails->className === 'Date'){
                     $dateTime = $value->format('Y-m-d');

--- a/lib/net/authorize/api/contract/v1/LogoutResponse.php
+++ b/lib/net/authorize/api/contract/v1/LogoutResponse.php
@@ -15,7 +15,7 @@ class LogoutResponse extends ANetApiResponseType
         if(is_array($data) || is_object($data)) {
 			$mapper = \net\authorize\util\Mapper::Instance();
 			foreach($data AS $key => $value) {
-				$classDetails = $mapper->getClass(get_class() , $key);
+				$classDetails = $mapper->getClass(get_class($this) , $key);
 	 
 				if($classDetails !== NULL ) {
 					if ($classDetails->isArray) {

--- a/lib/net/authorize/api/contract/v1/MerchantAuthenticationType.php
+++ b/lib/net/authorize/api/contract/v1/MerchantAuthenticationType.php
@@ -265,7 +265,7 @@ class MerchantAuthenticationType implements \JsonSerializable
         });
         $mapper = \net\authorize\util\Mapper::Instance();
         foreach($values as $key => $value){
-            $classDetails = $mapper->getClass(get_class() , $key);
+            $classDetails = $mapper->getClass(get_class($this) , $key);
             if (isset($value)){
                 if ($classDetails->className === 'Date'){
                     $dateTime = $value->format('Y-m-d');
@@ -293,7 +293,7 @@ class MerchantAuthenticationType implements \JsonSerializable
         if(is_array($data) || is_object($data)) {
 			$mapper = \net\authorize\util\Mapper::Instance();
 			foreach($data AS $key => $value) {
-				$classDetails = $mapper->getClass(get_class() , $key);
+				$classDetails = $mapper->getClass(get_class($this) , $key);
 	 
 				if($classDetails !== NULL ) {
 					if ($classDetails->isArray) {

--- a/lib/net/authorize/api/contract/v1/MerchantContactType.php
+++ b/lib/net/authorize/api/contract/v1/MerchantContactType.php
@@ -182,7 +182,7 @@ class MerchantContactType implements \JsonSerializable
         });
         $mapper = \net\authorize\util\Mapper::Instance();
         foreach($values as $key => $value){
-            $classDetails = $mapper->getClass(get_class() , $key);
+            $classDetails = $mapper->getClass(get_class($this) , $key);
             if (isset($value)){
                 if ($classDetails->className === 'Date'){
                     $dateTime = $value->format('Y-m-d');
@@ -210,7 +210,7 @@ class MerchantContactType implements \JsonSerializable
         if(is_array($data) || is_object($data)) {
 			$mapper = \net\authorize\util\Mapper::Instance();
 			foreach($data AS $key => $value) {
-				$classDetails = $mapper->getClass(get_class() , $key);
+				$classDetails = $mapper->getClass(get_class($this) , $key);
 	 
 				if($classDetails !== NULL ) {
 					if ($classDetails->isArray) {

--- a/lib/net/authorize/api/contract/v1/MessagesType.php
+++ b/lib/net/authorize/api/contract/v1/MessagesType.php
@@ -108,7 +108,7 @@ class MessagesType implements \JsonSerializable
         });
         $mapper = \net\authorize\util\Mapper::Instance();
         foreach($values as $key => $value){
-            $classDetails = $mapper->getClass(get_class() , $key);
+            $classDetails = $mapper->getClass(get_class($this) , $key);
             if (isset($value)){
                 if ($classDetails->className === 'Date'){
                     $dateTime = $value->format('Y-m-d');
@@ -136,7 +136,7 @@ class MessagesType implements \JsonSerializable
         if(is_array($data) || is_object($data)) {
 			$mapper = \net\authorize\util\Mapper::Instance();
 			foreach($data AS $key => $value) {
-				$classDetails = $mapper->getClass(get_class() , $key);
+				$classDetails = $mapper->getClass(get_class($this) , $key);
 	 
 				if($classDetails !== NULL ) {
 					if ($classDetails->isArray) {

--- a/lib/net/authorize/api/contract/v1/MessagesType/MessageAType.php
+++ b/lib/net/authorize/api/contract/v1/MessagesType/MessageAType.php
@@ -71,7 +71,7 @@ class MessageAType implements \JsonSerializable
         });
         $mapper = \net\authorize\util\Mapper::Instance();
         foreach($values as $key => $value){
-            $classDetails = $mapper->getClass(get_class() , $key);
+            $classDetails = $mapper->getClass(get_class($this) , $key);
             if (isset($value)){
                 if ($classDetails->className === 'Date'){
                     $dateTime = $value->format('Y-m-d');
@@ -99,7 +99,7 @@ class MessageAType implements \JsonSerializable
         if(is_array($data) || is_object($data)) {
 			$mapper = \net\authorize\util\Mapper::Instance();
 			foreach($data AS $key => $value) {
-				$classDetails = $mapper->getClass(get_class() , $key);
+				$classDetails = $mapper->getClass(get_class($this) , $key);
 	 
 				if($classDetails !== NULL ) {
 					if ($classDetails->isArray) {

--- a/lib/net/authorize/api/contract/v1/MobileDeviceLoginRequest.php
+++ b/lib/net/authorize/api/contract/v1/MobileDeviceLoginRequest.php
@@ -17,7 +17,7 @@ class MobileDeviceLoginRequest extends ANetApiRequestType
         });
         $mapper = \net\authorize\util\Mapper::Instance();
         foreach($values as $key => $value){
-            $classDetails = $mapper->getClass(get_class() , $key);
+            $classDetails = $mapper->getClass(get_class($this) , $key);
             if (isset($value)){
                 if ($classDetails->className === 'Date'){
                     $dateTime = $value->format('Y-m-d');

--- a/lib/net/authorize/api/contract/v1/MobileDeviceLoginResponse.php
+++ b/lib/net/authorize/api/contract/v1/MobileDeviceLoginResponse.php
@@ -130,7 +130,7 @@ class MobileDeviceLoginResponse extends ANetApiResponseType
         if(is_array($data) || is_object($data)) {
 			$mapper = \net\authorize\util\Mapper::Instance();
 			foreach($data AS $key => $value) {
-				$classDetails = $mapper->getClass(get_class() , $key);
+				$classDetails = $mapper->getClass(get_class($this) , $key);
 	 
 				if($classDetails !== NULL ) {
 					if ($classDetails->isArray) {

--- a/lib/net/authorize/api/contract/v1/MobileDeviceRegistrationRequest.php
+++ b/lib/net/authorize/api/contract/v1/MobileDeviceRegistrationRequest.php
@@ -44,7 +44,7 @@ class MobileDeviceRegistrationRequest extends ANetApiRequestType
         });
         $mapper = \net\authorize\util\Mapper::Instance();
         foreach($values as $key => $value){
-            $classDetails = $mapper->getClass(get_class() , $key);
+            $classDetails = $mapper->getClass(get_class($this) , $key);
             if (isset($value)){
                 if ($classDetails->className === 'Date'){
                     $dateTime = $value->format('Y-m-d');

--- a/lib/net/authorize/api/contract/v1/MobileDeviceRegistrationResponse.php
+++ b/lib/net/authorize/api/contract/v1/MobileDeviceRegistrationResponse.php
@@ -15,7 +15,7 @@ class MobileDeviceRegistrationResponse extends ANetApiResponseType
         if(is_array($data) || is_object($data)) {
 			$mapper = \net\authorize\util\Mapper::Instance();
 			foreach($data AS $key => $value) {
-				$classDetails = $mapper->getClass(get_class() , $key);
+				$classDetails = $mapper->getClass(get_class($this) , $key);
 	 
 				if($classDetails !== NULL ) {
 					if ($classDetails->isArray) {

--- a/lib/net/authorize/api/contract/v1/MobileDeviceType.php
+++ b/lib/net/authorize/api/contract/v1/MobileDeviceType.php
@@ -155,7 +155,7 @@ class MobileDeviceType implements \JsonSerializable
         });
         $mapper = \net\authorize\util\Mapper::Instance();
         foreach($values as $key => $value){
-            $classDetails = $mapper->getClass(get_class() , $key);
+            $classDetails = $mapper->getClass(get_class($this) , $key);
             if (isset($value)){
                 if ($classDetails->className === 'Date'){
                     $dateTime = $value->format('Y-m-d');
@@ -183,7 +183,7 @@ class MobileDeviceType implements \JsonSerializable
         if(is_array($data) || is_object($data)) {
 			$mapper = \net\authorize\util\Mapper::Instance();
 			foreach($data AS $key => $value) {
-				$classDetails = $mapper->getClass(get_class() , $key);
+				$classDetails = $mapper->getClass(get_class($this) , $key);
 	 
 				if($classDetails !== NULL ) {
 					if ($classDetails->isArray) {

--- a/lib/net/authorize/api/contract/v1/NameAndAddressType.php
+++ b/lib/net/authorize/api/contract/v1/NameAndAddressType.php
@@ -236,7 +236,7 @@ class NameAndAddressType implements \JsonSerializable
         });
         $mapper = \net\authorize\util\Mapper::Instance();
         foreach($values as $key => $value){
-            $classDetails = $mapper->getClass(get_class() , $key);
+            $classDetails = $mapper->getClass(get_class($this) , $key);
             if (isset($value)){
                 if ($classDetails->className === 'Date'){
                     $dateTime = $value->format('Y-m-d');
@@ -264,7 +264,7 @@ class NameAndAddressType implements \JsonSerializable
         if(is_array($data) || is_object($data)) {
 			$mapper = \net\authorize\util\Mapper::Instance();
 			foreach($data AS $key => $value) {
-				$classDetails = $mapper->getClass(get_class() , $key);
+				$classDetails = $mapper->getClass(get_class($this) , $key);
 	 
 				if($classDetails !== NULL ) {
 					if ($classDetails->isArray) {

--- a/lib/net/authorize/api/contract/v1/OpaqueDataType.php
+++ b/lib/net/authorize/api/contract/v1/OpaqueDataType.php
@@ -128,7 +128,7 @@ class OpaqueDataType implements \JsonSerializable
         });
         $mapper = \net\authorize\util\Mapper::Instance();
         foreach($values as $key => $value){
-            $classDetails = $mapper->getClass(get_class() , $key);
+            $classDetails = $mapper->getClass(get_class($this) , $key);
             if (isset($value)){
                 if ($classDetails->className === 'Date'){
                     $dateTime = $value->format('Y-m-d');
@@ -156,7 +156,7 @@ class OpaqueDataType implements \JsonSerializable
         if(is_array($data) || is_object($data)) {
 			$mapper = \net\authorize\util\Mapper::Instance();
 			foreach($data AS $key => $value) {
-				$classDetails = $mapper->getClass(get_class() , $key);
+				$classDetails = $mapper->getClass(get_class($this) , $key);
 	 
 				if($classDetails !== NULL ) {
 					if ($classDetails->isArray) {

--- a/lib/net/authorize/api/contract/v1/OrderExType.php
+++ b/lib/net/authorize/api/contract/v1/OrderExType.php
@@ -47,7 +47,7 @@ class OrderExType extends OrderType implements \JsonSerializable
         });
         $mapper = \net\authorize\util\Mapper::Instance();
         foreach($values as $key => $value){
-            $classDetails = $mapper->getClass(get_class() , $key);
+            $classDetails = $mapper->getClass(get_class($this) , $key);
             if (isset($value)){
                 if ($classDetails->className === 'Date'){
                     $dateTime = $value->format('Y-m-d');
@@ -75,7 +75,7 @@ class OrderExType extends OrderType implements \JsonSerializable
         if(is_array($data) || is_object($data)) {
 			$mapper = \net\authorize\util\Mapper::Instance();
 			foreach($data AS $key => $value) {
-				$classDetails = $mapper->getClass(get_class() , $key);
+				$classDetails = $mapper->getClass(get_class($this) , $key);
 	 
 				if($classDetails !== NULL ) {
 					if ($classDetails->isArray) {

--- a/lib/net/authorize/api/contract/v1/OrderType.php
+++ b/lib/net/authorize/api/contract/v1/OrderType.php
@@ -506,7 +506,7 @@ class OrderType implements \JsonSerializable
         });
         $mapper = \net\authorize\util\Mapper::Instance();
         foreach($values as $key => $value){
-            $classDetails = $mapper->getClass(get_class() , $key);
+            $classDetails = $mapper->getClass(get_class($this) , $key);
             if (isset($value)){
                 if ($classDetails->className === 'Date'){
                     $dateTime = $value->format('Y-m-d');
@@ -534,7 +534,7 @@ class OrderType implements \JsonSerializable
         if(is_array($data) || is_object($data)) {
 			$mapper = \net\authorize\util\Mapper::Instance();
 			foreach($data AS $key => $value) {
-				$classDetails = $mapper->getClass(get_class() , $key);
+				$classDetails = $mapper->getClass(get_class($this) , $key);
 	 
 				if($classDetails !== NULL ) {
 					if ($classDetails->isArray) {

--- a/lib/net/authorize/api/contract/v1/OtherTaxType.php
+++ b/lib/net/authorize/api/contract/v1/OtherTaxType.php
@@ -182,7 +182,7 @@ class OtherTaxType implements \JsonSerializable
         });
         $mapper = \net\authorize\util\Mapper::Instance();
         foreach($values as $key => $value){
-            $classDetails = $mapper->getClass(get_class() , $key);
+            $classDetails = $mapper->getClass(get_class($this) , $key);
             if (isset($value)){
                 if ($classDetails->className === 'Date'){
                     $dateTime = $value->format('Y-m-d');
@@ -210,7 +210,7 @@ class OtherTaxType implements \JsonSerializable
         if(is_array($data) || is_object($data)) {
 			$mapper = \net\authorize\util\Mapper::Instance();
 			foreach($data AS $key => $value) {
-				$classDetails = $mapper->getClass(get_class() , $key);
+				$classDetails = $mapper->getClass(get_class($this) , $key);
 	 
 				if($classDetails !== NULL ) {
 					if ($classDetails->isArray) {

--- a/lib/net/authorize/api/contract/v1/PagingType.php
+++ b/lib/net/authorize/api/contract/v1/PagingType.php
@@ -74,7 +74,7 @@ class PagingType implements \JsonSerializable
         });
         $mapper = \net\authorize\util\Mapper::Instance();
         foreach($values as $key => $value){
-            $classDetails = $mapper->getClass(get_class() , $key);
+            $classDetails = $mapper->getClass(get_class($this) , $key);
             if (isset($value)){
                 if ($classDetails->className === 'Date'){
                     $dateTime = $value->format('Y-m-d');
@@ -102,7 +102,7 @@ class PagingType implements \JsonSerializable
         if(is_array($data) || is_object($data)) {
 			$mapper = \net\authorize\util\Mapper::Instance();
 			foreach($data AS $key => $value) {
-				$classDetails = $mapper->getClass(get_class() , $key);
+				$classDetails = $mapper->getClass(get_class($this) , $key);
 	 
 				if($classDetails !== NULL ) {
 					if ($classDetails->isArray) {

--- a/lib/net/authorize/api/contract/v1/PayPalType.php
+++ b/lib/net/authorize/api/contract/v1/PayPalType.php
@@ -182,7 +182,7 @@ class PayPalType implements \JsonSerializable
         });
         $mapper = \net\authorize\util\Mapper::Instance();
         foreach($values as $key => $value){
-            $classDetails = $mapper->getClass(get_class() , $key);
+            $classDetails = $mapper->getClass(get_class($this) , $key);
             if (isset($value)){
                 if ($classDetails->className === 'Date'){
                     $dateTime = $value->format('Y-m-d');
@@ -210,7 +210,7 @@ class PayPalType implements \JsonSerializable
         if(is_array($data) || is_object($data)) {
 			$mapper = \net\authorize\util\Mapper::Instance();
 			foreach($data AS $key => $value) {
-				$classDetails = $mapper->getClass(get_class() , $key);
+				$classDetails = $mapper->getClass(get_class($this) , $key);
 	 
 				if($classDetails !== NULL ) {
 					if ($classDetails->isArray) {

--- a/lib/net/authorize/api/contract/v1/PaymentDetailsType.php
+++ b/lib/net/authorize/api/contract/v1/PaymentDetailsType.php
@@ -290,7 +290,7 @@ class PaymentDetailsType implements \JsonSerializable
         });
         $mapper = \net\authorize\util\Mapper::Instance();
         foreach($values as $key => $value){
-            $classDetails = $mapper->getClass(get_class() , $key);
+            $classDetails = $mapper->getClass(get_class($this) , $key);
             if (isset($value)){
                 if ($classDetails->className === 'Date'){
                     $dateTime = $value->format('Y-m-d');
@@ -318,7 +318,7 @@ class PaymentDetailsType implements \JsonSerializable
         if(is_array($data) || is_object($data)) {
 			$mapper = \net\authorize\util\Mapper::Instance();
 			foreach($data AS $key => $value) {
-				$classDetails = $mapper->getClass(get_class() , $key);
+				$classDetails = $mapper->getClass(get_class($this) , $key);
 	 
 				if($classDetails !== NULL ) {
 					if ($classDetails->isArray) {

--- a/lib/net/authorize/api/contract/v1/PaymentEmvType.php
+++ b/lib/net/authorize/api/contract/v1/PaymentEmvType.php
@@ -101,7 +101,7 @@ class PaymentEmvType implements \JsonSerializable
         });
         $mapper = \net\authorize\util\Mapper::Instance();
         foreach($values as $key => $value){
-            $classDetails = $mapper->getClass(get_class() , $key);
+            $classDetails = $mapper->getClass(get_class($this) , $key);
             if (isset($value)){
                 if ($classDetails->className === 'Date'){
                     $dateTime = $value->format('Y-m-d');
@@ -129,7 +129,7 @@ class PaymentEmvType implements \JsonSerializable
         if(is_array($data) || is_object($data)) {
 			$mapper = \net\authorize\util\Mapper::Instance();
 			foreach($data AS $key => $value) {
-				$classDetails = $mapper->getClass(get_class() , $key);
+				$classDetails = $mapper->getClass(get_class($this) , $key);
 	 
 				if($classDetails !== NULL ) {
 					if ($classDetails->isArray) {

--- a/lib/net/authorize/api/contract/v1/PaymentMaskedType.php
+++ b/lib/net/authorize/api/contract/v1/PaymentMaskedType.php
@@ -101,7 +101,7 @@ class PaymentMaskedType implements \JsonSerializable
         });
         $mapper = \net\authorize\util\Mapper::Instance();
         foreach($values as $key => $value){
-            $classDetails = $mapper->getClass(get_class() , $key);
+            $classDetails = $mapper->getClass(get_class($this) , $key);
             if (isset($value)){
                 if ($classDetails->className === 'Date'){
                     $dateTime = $value->format('Y-m-d');
@@ -129,7 +129,7 @@ class PaymentMaskedType implements \JsonSerializable
         if(is_array($data) || is_object($data)) {
 			$mapper = \net\authorize\util\Mapper::Instance();
 			foreach($data AS $key => $value) {
-				$classDetails = $mapper->getClass(get_class() , $key);
+				$classDetails = $mapper->getClass(get_class($this) , $key);
 	 
 				if($classDetails !== NULL ) {
 					if ($classDetails->isArray) {

--- a/lib/net/authorize/api/contract/v1/PaymentProfileType.php
+++ b/lib/net/authorize/api/contract/v1/PaymentProfileType.php
@@ -74,7 +74,7 @@ class PaymentProfileType implements \JsonSerializable
         });
         $mapper = \net\authorize\util\Mapper::Instance();
         foreach($values as $key => $value){
-            $classDetails = $mapper->getClass(get_class() , $key);
+            $classDetails = $mapper->getClass(get_class($this) , $key);
             if (isset($value)){
                 if ($classDetails->className === 'Date'){
                     $dateTime = $value->format('Y-m-d');
@@ -102,7 +102,7 @@ class PaymentProfileType implements \JsonSerializable
         if(is_array($data) || is_object($data)) {
 			$mapper = \net\authorize\util\Mapper::Instance();
 			foreach($data AS $key => $value) {
-				$classDetails = $mapper->getClass(get_class() , $key);
+				$classDetails = $mapper->getClass(get_class($this) , $key);
 	 
 				if($classDetails !== NULL ) {
 					if ($classDetails->isArray) {

--- a/lib/net/authorize/api/contract/v1/PaymentScheduleType.php
+++ b/lib/net/authorize/api/contract/v1/PaymentScheduleType.php
@@ -131,7 +131,7 @@ class PaymentScheduleType implements \JsonSerializable
         });
         $mapper = \net\authorize\util\Mapper::Instance();
         foreach($values as $key => $value){
-            $classDetails = $mapper->getClass(get_class() , $key);
+            $classDetails = $mapper->getClass(get_class($this) , $key);
             if (isset($value)){
                 if ($classDetails->className === 'Date'){
                     $dateTime = $value->format('Y-m-d');
@@ -159,7 +159,7 @@ class PaymentScheduleType implements \JsonSerializable
         if(is_array($data) || is_object($data)) {
 			$mapper = \net\authorize\util\Mapper::Instance();
 			foreach($data AS $key => $value) {
-				$classDetails = $mapper->getClass(get_class() , $key);
+				$classDetails = $mapper->getClass(get_class($this) , $key);
 	 
 				if($classDetails !== NULL ) {
 					if ($classDetails->isArray) {

--- a/lib/net/authorize/api/contract/v1/PaymentScheduleType/IntervalAType.php
+++ b/lib/net/authorize/api/contract/v1/PaymentScheduleType/IntervalAType.php
@@ -71,7 +71,7 @@ class IntervalAType implements \JsonSerializable
         });
         $mapper = \net\authorize\util\Mapper::Instance();
         foreach($values as $key => $value){
-            $classDetails = $mapper->getClass(get_class() , $key);
+            $classDetails = $mapper->getClass(get_class($this) , $key);
             if (isset($value)){
                 if ($classDetails->className === 'Date'){
                     $dateTime = $value->format('Y-m-d');
@@ -99,7 +99,7 @@ class IntervalAType implements \JsonSerializable
         if(is_array($data) || is_object($data)) {
 			$mapper = \net\authorize\util\Mapper::Instance();
 			foreach($data AS $key => $value) {
-				$classDetails = $mapper->getClass(get_class() , $key);
+				$classDetails = $mapper->getClass(get_class($this) , $key);
 	 
 				if($classDetails !== NULL ) {
 					if ($classDetails->isArray) {

--- a/lib/net/authorize/api/contract/v1/PaymentSimpleType.php
+++ b/lib/net/authorize/api/contract/v1/PaymentSimpleType.php
@@ -74,7 +74,7 @@ class PaymentSimpleType implements \JsonSerializable
         });
         $mapper = \net\authorize\util\Mapper::Instance();
         foreach($values as $key => $value){
-            $classDetails = $mapper->getClass(get_class() , $key);
+            $classDetails = $mapper->getClass(get_class($this) , $key);
             if (isset($value)){
                 if ($classDetails->className === 'Date'){
                     $dateTime = $value->format('Y-m-d');
@@ -102,7 +102,7 @@ class PaymentSimpleType implements \JsonSerializable
         if(is_array($data) || is_object($data)) {
 			$mapper = \net\authorize\util\Mapper::Instance();
 			foreach($data AS $key => $value) {
-				$classDetails = $mapper->getClass(get_class() , $key);
+				$classDetails = $mapper->getClass(get_class($this) , $key);
 	 
 				if($classDetails !== NULL ) {
 					if ($classDetails->isArray) {

--- a/lib/net/authorize/api/contract/v1/PaymentType.php
+++ b/lib/net/authorize/api/contract/v1/PaymentType.php
@@ -237,7 +237,7 @@ class PaymentType implements \JsonSerializable
         });
         $mapper = \net\authorize\util\Mapper::Instance();
         foreach($values as $key => $value){
-            $classDetails = $mapper->getClass(get_class() , $key);
+            $classDetails = $mapper->getClass(get_class($this) , $key);
             if (isset($value)){
                 if ($classDetails->className === 'Date'){
                     $dateTime = $value->format('Y-m-d');
@@ -265,7 +265,7 @@ class PaymentType implements \JsonSerializable
         if(is_array($data) || is_object($data)) {
 			$mapper = \net\authorize\util\Mapper::Instance();
 			foreach($data AS $key => $value) {
-				$classDetails = $mapper->getClass(get_class() , $key);
+				$classDetails = $mapper->getClass(get_class($this) , $key);
 	 
 				if($classDetails !== NULL ) {
 					if ($classDetails->isArray) {

--- a/lib/net/authorize/api/contract/v1/PermissionType.php
+++ b/lib/net/authorize/api/contract/v1/PermissionType.php
@@ -47,7 +47,7 @@ class PermissionType implements \JsonSerializable
         });
         $mapper = \net\authorize\util\Mapper::Instance();
         foreach($values as $key => $value){
-            $classDetails = $mapper->getClass(get_class() , $key);
+            $classDetails = $mapper->getClass(get_class($this) , $key);
             if (isset($value)){
                 if ($classDetails->className === 'Date'){
                     $dateTime = $value->format('Y-m-d');
@@ -75,7 +75,7 @@ class PermissionType implements \JsonSerializable
         if(is_array($data) || is_object($data)) {
 			$mapper = \net\authorize\util\Mapper::Instance();
 			foreach($data AS $key => $value) {
-				$classDetails = $mapper->getClass(get_class() , $key);
+				$classDetails = $mapper->getClass(get_class($this) , $key);
 	 
 				if($classDetails !== NULL ) {
 					if ($classDetails->isArray) {

--- a/lib/net/authorize/api/contract/v1/ProcessingOptionsType.php
+++ b/lib/net/authorize/api/contract/v1/ProcessingOptionsType.php
@@ -128,7 +128,7 @@ class ProcessingOptionsType implements \JsonSerializable
         });
         $mapper = \net\authorize\util\Mapper::Instance();
         foreach($values as $key => $value){
-            $classDetails = $mapper->getClass(get_class() , $key);
+            $classDetails = $mapper->getClass(get_class($this) , $key);
             if (isset($value)){
                 if ($classDetails->className === 'Date'){
                     $dateTime = $value->format('Y-m-d');
@@ -156,7 +156,7 @@ class ProcessingOptionsType implements \JsonSerializable
         if(is_array($data) || is_object($data)) {
 			$mapper = \net\authorize\util\Mapper::Instance();
 			foreach($data AS $key => $value) {
-				$classDetails = $mapper->getClass(get_class() , $key);
+				$classDetails = $mapper->getClass(get_class($this) , $key);
 	 
 				if($classDetails !== NULL ) {
 					if ($classDetails->isArray) {

--- a/lib/net/authorize/api/contract/v1/ProcessorType.php
+++ b/lib/net/authorize/api/contract/v1/ProcessorType.php
@@ -135,7 +135,7 @@ class ProcessorType implements \JsonSerializable
         });
         $mapper = \net\authorize\util\Mapper::Instance();
         foreach($values as $key => $value){
-            $classDetails = $mapper->getClass(get_class() , $key);
+            $classDetails = $mapper->getClass(get_class($this) , $key);
             if (isset($value)){
                 if ($classDetails->className === 'Date'){
                     $dateTime = $value->format('Y-m-d');
@@ -163,7 +163,7 @@ class ProcessorType implements \JsonSerializable
         if(is_array($data) || is_object($data)) {
 			$mapper = \net\authorize\util\Mapper::Instance();
 			foreach($data AS $key => $value) {
-				$classDetails = $mapper->getClass(get_class() , $key);
+				$classDetails = $mapper->getClass(get_class($this) , $key);
 	 
 				if($classDetails !== NULL ) {
 					if ($classDetails->isArray) {

--- a/lib/net/authorize/api/contract/v1/ProfileTransAmountType.php
+++ b/lib/net/authorize/api/contract/v1/ProfileTransAmountType.php
@@ -189,7 +189,7 @@ class ProfileTransAmountType implements \JsonSerializable
         });
         $mapper = \net\authorize\util\Mapper::Instance();
         foreach($values as $key => $value){
-            $classDetails = $mapper->getClass(get_class() , $key);
+            $classDetails = $mapper->getClass(get_class($this) , $key);
             if (isset($value)){
                 if ($classDetails->className === 'Date'){
                     $dateTime = $value->format('Y-m-d');
@@ -217,7 +217,7 @@ class ProfileTransAmountType implements \JsonSerializable
         if(is_array($data) || is_object($data)) {
 			$mapper = \net\authorize\util\Mapper::Instance();
 			foreach($data AS $key => $value) {
-				$classDetails = $mapper->getClass(get_class() , $key);
+				$classDetails = $mapper->getClass(get_class($this) , $key);
 	 
 				if($classDetails !== NULL ) {
 					if ($classDetails->isArray) {

--- a/lib/net/authorize/api/contract/v1/ProfileTransAuthCaptureType.php
+++ b/lib/net/authorize/api/contract/v1/ProfileTransAuthCaptureType.php
@@ -20,7 +20,7 @@ class ProfileTransAuthCaptureType extends ProfileTransOrderType implements \Json
         });
         $mapper = \net\authorize\util\Mapper::Instance();
         foreach($values as $key => $value){
-            $classDetails = $mapper->getClass(get_class() , $key);
+            $classDetails = $mapper->getClass(get_class($this) , $key);
             if (isset($value)){
                 if ($classDetails->className === 'Date'){
                     $dateTime = $value->format('Y-m-d');
@@ -48,7 +48,7 @@ class ProfileTransAuthCaptureType extends ProfileTransOrderType implements \Json
         if(is_array($data) || is_object($data)) {
 			$mapper = \net\authorize\util\Mapper::Instance();
 			foreach($data AS $key => $value) {
-				$classDetails = $mapper->getClass(get_class() , $key);
+				$classDetails = $mapper->getClass(get_class($this) , $key);
 	 
 				if($classDetails !== NULL ) {
 					if ($classDetails->isArray) {

--- a/lib/net/authorize/api/contract/v1/ProfileTransAuthOnlyType.php
+++ b/lib/net/authorize/api/contract/v1/ProfileTransAuthOnlyType.php
@@ -20,7 +20,7 @@ class ProfileTransAuthOnlyType extends ProfileTransOrderType implements \JsonSer
         });
         $mapper = \net\authorize\util\Mapper::Instance();
         foreach($values as $key => $value){
-            $classDetails = $mapper->getClass(get_class() , $key);
+            $classDetails = $mapper->getClass(get_class($this) , $key);
             if (isset($value)){
                 if ($classDetails->className === 'Date'){
                     $dateTime = $value->format('Y-m-d');
@@ -48,7 +48,7 @@ class ProfileTransAuthOnlyType extends ProfileTransOrderType implements \JsonSer
         if(is_array($data) || is_object($data)) {
 			$mapper = \net\authorize\util\Mapper::Instance();
 			foreach($data AS $key => $value) {
-				$classDetails = $mapper->getClass(get_class() , $key);
+				$classDetails = $mapper->getClass(get_class($this) , $key);
 	 
 				if($classDetails !== NULL ) {
 					if ($classDetails->isArray) {

--- a/lib/net/authorize/api/contract/v1/ProfileTransCaptureOnlyType.php
+++ b/lib/net/authorize/api/contract/v1/ProfileTransCaptureOnlyType.php
@@ -47,7 +47,7 @@ class ProfileTransCaptureOnlyType extends ProfileTransOrderType implements \Json
         });
         $mapper = \net\authorize\util\Mapper::Instance();
         foreach($values as $key => $value){
-            $classDetails = $mapper->getClass(get_class() , $key);
+            $classDetails = $mapper->getClass(get_class($this) , $key);
             if (isset($value)){
                 if ($classDetails->className === 'Date'){
                     $dateTime = $value->format('Y-m-d');
@@ -75,7 +75,7 @@ class ProfileTransCaptureOnlyType extends ProfileTransOrderType implements \Json
         if(is_array($data) || is_object($data)) {
 			$mapper = \net\authorize\util\Mapper::Instance();
 			foreach($data AS $key => $value) {
-				$classDetails = $mapper->getClass(get_class() , $key);
+				$classDetails = $mapper->getClass(get_class($this) , $key);
 	 
 				if($classDetails !== NULL ) {
 					if ($classDetails->isArray) {

--- a/lib/net/authorize/api/contract/v1/ProfileTransOrderType.php
+++ b/lib/net/authorize/api/contract/v1/ProfileTransOrderType.php
@@ -322,7 +322,7 @@ class ProfileTransOrderType extends ProfileTransAmountType implements \JsonSeria
         });
         $mapper = \net\authorize\util\Mapper::Instance();
         foreach($values as $key => $value){
-            $classDetails = $mapper->getClass(get_class() , $key);
+            $classDetails = $mapper->getClass(get_class($this) , $key);
             if (isset($value)){
                 if ($classDetails->className === 'Date'){
                     $dateTime = $value->format('Y-m-d');
@@ -350,7 +350,7 @@ class ProfileTransOrderType extends ProfileTransAmountType implements \JsonSeria
         if(is_array($data) || is_object($data)) {
 			$mapper = \net\authorize\util\Mapper::Instance();
 			foreach($data AS $key => $value) {
-				$classDetails = $mapper->getClass(get_class() , $key);
+				$classDetails = $mapper->getClass(get_class($this) , $key);
 	 
 				if($classDetails !== NULL ) {
 					if ($classDetails->isArray) {

--- a/lib/net/authorize/api/contract/v1/ProfileTransPriorAuthCaptureType.php
+++ b/lib/net/authorize/api/contract/v1/ProfileTransPriorAuthCaptureType.php
@@ -128,7 +128,7 @@ class ProfileTransPriorAuthCaptureType extends ProfileTransAmountType implements
         });
         $mapper = \net\authorize\util\Mapper::Instance();
         foreach($values as $key => $value){
-            $classDetails = $mapper->getClass(get_class() , $key);
+            $classDetails = $mapper->getClass(get_class($this) , $key);
             if (isset($value)){
                 if ($classDetails->className === 'Date'){
                     $dateTime = $value->format('Y-m-d');
@@ -156,7 +156,7 @@ class ProfileTransPriorAuthCaptureType extends ProfileTransAmountType implements
         if(is_array($data) || is_object($data)) {
 			$mapper = \net\authorize\util\Mapper::Instance();
 			foreach($data AS $key => $value) {
-				$classDetails = $mapper->getClass(get_class() , $key);
+				$classDetails = $mapper->getClass(get_class($this) , $key);
 	 
 				if($classDetails !== NULL ) {
 					if ($classDetails->isArray) {

--- a/lib/net/authorize/api/contract/v1/ProfileTransRefundType.php
+++ b/lib/net/authorize/api/contract/v1/ProfileTransRefundType.php
@@ -236,7 +236,7 @@ class ProfileTransRefundType extends ProfileTransAmountType implements \JsonSeri
         });
         $mapper = \net\authorize\util\Mapper::Instance();
         foreach($values as $key => $value){
-            $classDetails = $mapper->getClass(get_class() , $key);
+            $classDetails = $mapper->getClass(get_class($this) , $key);
             if (isset($value)){
                 if ($classDetails->className === 'Date'){
                     $dateTime = $value->format('Y-m-d');
@@ -264,7 +264,7 @@ class ProfileTransRefundType extends ProfileTransAmountType implements \JsonSeri
         if(is_array($data) || is_object($data)) {
 			$mapper = \net\authorize\util\Mapper::Instance();
 			foreach($data AS $key => $value) {
-				$classDetails = $mapper->getClass(get_class() , $key);
+				$classDetails = $mapper->getClass(get_class($this) , $key);
 	 
 				if($classDetails !== NULL ) {
 					if ($classDetails->isArray) {

--- a/lib/net/authorize/api/contract/v1/ProfileTransVoidType.php
+++ b/lib/net/authorize/api/contract/v1/ProfileTransVoidType.php
@@ -128,7 +128,7 @@ class ProfileTransVoidType implements \JsonSerializable
         });
         $mapper = \net\authorize\util\Mapper::Instance();
         foreach($values as $key => $value){
-            $classDetails = $mapper->getClass(get_class() , $key);
+            $classDetails = $mapper->getClass(get_class($this) , $key);
             if (isset($value)){
                 if ($classDetails->className === 'Date'){
                     $dateTime = $value->format('Y-m-d');
@@ -156,7 +156,7 @@ class ProfileTransVoidType implements \JsonSerializable
         if(is_array($data) || is_object($data)) {
 			$mapper = \net\authorize\util\Mapper::Instance();
 			foreach($data AS $key => $value) {
-				$classDetails = $mapper->getClass(get_class() , $key);
+				$classDetails = $mapper->getClass(get_class($this) , $key);
 	 
 				if($classDetails !== NULL ) {
 					if ($classDetails->isArray) {

--- a/lib/net/authorize/api/contract/v1/ProfileTransactionType.php
+++ b/lib/net/authorize/api/contract/v1/ProfileTransactionType.php
@@ -191,7 +191,7 @@ class ProfileTransactionType implements \JsonSerializable
         });
         $mapper = \net\authorize\util\Mapper::Instance();
         foreach($values as $key => $value){
-            $classDetails = $mapper->getClass(get_class() , $key);
+            $classDetails = $mapper->getClass(get_class($this) , $key);
             if (isset($value)){
                 if ($classDetails->className === 'Date'){
                     $dateTime = $value->format('Y-m-d');
@@ -219,7 +219,7 @@ class ProfileTransactionType implements \JsonSerializable
         if(is_array($data) || is_object($data)) {
 			$mapper = \net\authorize\util\Mapper::Instance();
 			foreach($data AS $key => $value) {
-				$classDetails = $mapper->getClass(get_class() , $key);
+				$classDetails = $mapper->getClass(get_class($this) , $key);
 	 
 				if($classDetails !== NULL ) {
 					if ($classDetails->isArray) {

--- a/lib/net/authorize/api/contract/v1/ReturnedItemType.php
+++ b/lib/net/authorize/api/contract/v1/ReturnedItemType.php
@@ -155,7 +155,7 @@ class ReturnedItemType implements \JsonSerializable
         });
         $mapper = \net\authorize\util\Mapper::Instance();
         foreach($values as $key => $value){
-            $classDetails = $mapper->getClass(get_class() , $key);
+            $classDetails = $mapper->getClass(get_class($this) , $key);
             if (isset($value)){
                 if ($classDetails->className === 'Date'){
                     $dateTime = $value->format('Y-m-d');
@@ -183,7 +183,7 @@ class ReturnedItemType implements \JsonSerializable
         if(is_array($data) || is_object($data)) {
 			$mapper = \net\authorize\util\Mapper::Instance();
 			foreach($data AS $key => $value) {
-				$classDetails = $mapper->getClass(get_class() , $key);
+				$classDetails = $mapper->getClass(get_class($this) , $key);
 	 
 				if($classDetails !== NULL ) {
 					if ($classDetails->isArray) {

--- a/lib/net/authorize/api/contract/v1/SecurePaymentContainerErrorType.php
+++ b/lib/net/authorize/api/contract/v1/SecurePaymentContainerErrorType.php
@@ -74,7 +74,7 @@ class SecurePaymentContainerErrorType implements \JsonSerializable
         });
         $mapper = \net\authorize\util\Mapper::Instance();
         foreach($values as $key => $value){
-            $classDetails = $mapper->getClass(get_class() , $key);
+            $classDetails = $mapper->getClass(get_class($this) , $key);
             if (isset($value)){
                 if ($classDetails->className === 'Date'){
                     $dateTime = $value->format('Y-m-d');
@@ -102,7 +102,7 @@ class SecurePaymentContainerErrorType implements \JsonSerializable
         if(is_array($data) || is_object($data)) {
 			$mapper = \net\authorize\util\Mapper::Instance();
 			foreach($data AS $key => $value) {
-				$classDetails = $mapper->getClass(get_class() , $key);
+				$classDetails = $mapper->getClass(get_class($this) , $key);
 	 
 				if($classDetails !== NULL ) {
 					if ($classDetails->isArray) {

--- a/lib/net/authorize/api/contract/v1/SecurePaymentContainerRequest.php
+++ b/lib/net/authorize/api/contract/v1/SecurePaymentContainerRequest.php
@@ -44,7 +44,7 @@ class SecurePaymentContainerRequest extends ANetApiRequestType
         });
         $mapper = \net\authorize\util\Mapper::Instance();
         foreach($values as $key => $value){
-            $classDetails = $mapper->getClass(get_class() , $key);
+            $classDetails = $mapper->getClass(get_class($this) , $key);
             if (isset($value)){
                 if ($classDetails->className === 'Date'){
                     $dateTime = $value->format('Y-m-d');

--- a/lib/net/authorize/api/contract/v1/SecurePaymentContainerResponse.php
+++ b/lib/net/authorize/api/contract/v1/SecurePaymentContainerResponse.php
@@ -42,7 +42,7 @@ class SecurePaymentContainerResponse extends ANetApiResponseType
         if(is_array($data) || is_object($data)) {
 			$mapper = \net\authorize\util\Mapper::Instance();
 			foreach($data AS $key => $value) {
-				$classDetails = $mapper->getClass(get_class() , $key);
+				$classDetails = $mapper->getClass(get_class($this) , $key);
 	 
 				if($classDetails !== NULL ) {
 					if ($classDetails->isArray) {

--- a/lib/net/authorize/api/contract/v1/SendCustomerTransactionReceiptRequest.php
+++ b/lib/net/authorize/api/contract/v1/SendCustomerTransactionReceiptRequest.php
@@ -98,7 +98,7 @@ class SendCustomerTransactionReceiptRequest extends ANetApiRequestType
         });
         $mapper = \net\authorize\util\Mapper::Instance();
         foreach($values as $key => $value){
-            $classDetails = $mapper->getClass(get_class() , $key);
+            $classDetails = $mapper->getClass(get_class($this) , $key);
             if (isset($value)){
                 if ($classDetails->className === 'Date'){
                     $dateTime = $value->format('Y-m-d');

--- a/lib/net/authorize/api/contract/v1/SendCustomerTransactionReceiptResponse.php
+++ b/lib/net/authorize/api/contract/v1/SendCustomerTransactionReceiptResponse.php
@@ -15,7 +15,7 @@ class SendCustomerTransactionReceiptResponse extends ANetApiResponseType
         if(is_array($data) || is_object($data)) {
 			$mapper = \net\authorize\util\Mapper::Instance();
 			foreach($data AS $key => $value) {
-				$classDetails = $mapper->getClass(get_class() , $key);
+				$classDetails = $mapper->getClass(get_class($this) , $key);
 	 
 				if($classDetails !== NULL ) {
 					if ($classDetails->isArray) {

--- a/lib/net/authorize/api/contract/v1/SettingType.php
+++ b/lib/net/authorize/api/contract/v1/SettingType.php
@@ -74,7 +74,7 @@ class SettingType implements \JsonSerializable
         });
         $mapper = \net\authorize\util\Mapper::Instance();
         foreach($values as $key => $value){
-            $classDetails = $mapper->getClass(get_class() , $key);
+            $classDetails = $mapper->getClass(get_class($this) , $key);
             if (isset($value)){
                 if ($classDetails->className === 'Date'){
                     $dateTime = $value->format('Y-m-d');
@@ -102,7 +102,7 @@ class SettingType implements \JsonSerializable
         if(is_array($data) || is_object($data)) {
 			$mapper = \net\authorize\util\Mapper::Instance();
 			foreach($data AS $key => $value) {
-				$classDetails = $mapper->getClass(get_class() , $key);
+				$classDetails = $mapper->getClass(get_class($this) , $key);
 	 
 				if($classDetails !== NULL ) {
 					if ($classDetails->isArray) {

--- a/lib/net/authorize/api/contract/v1/SolutionType.php
+++ b/lib/net/authorize/api/contract/v1/SolutionType.php
@@ -101,7 +101,7 @@ class SolutionType implements \JsonSerializable
         });
         $mapper = \net\authorize\util\Mapper::Instance();
         foreach($values as $key => $value){
-            $classDetails = $mapper->getClass(get_class() , $key);
+            $classDetails = $mapper->getClass(get_class($this) , $key);
             if (isset($value)){
                 if ($classDetails->className === 'Date'){
                     $dateTime = $value->format('Y-m-d');
@@ -129,7 +129,7 @@ class SolutionType implements \JsonSerializable
         if(is_array($data) || is_object($data)) {
 			$mapper = \net\authorize\util\Mapper::Instance();
 			foreach($data AS $key => $value) {
-				$classDetails = $mapper->getClass(get_class() , $key);
+				$classDetails = $mapper->getClass(get_class($this) , $key);
 	 
 				if($classDetails !== NULL ) {
 					if ($classDetails->isArray) {

--- a/lib/net/authorize/api/contract/v1/SubMerchantType.php
+++ b/lib/net/authorize/api/contract/v1/SubMerchantType.php
@@ -317,7 +317,7 @@ class SubMerchantType implements \JsonSerializable
         });
         $mapper = \net\authorize\util\Mapper::Instance();
         foreach($values as $key => $value){
-            $classDetails = $mapper->getClass(get_class() , $key);
+            $classDetails = $mapper->getClass(get_class($this) , $key);
             if (isset($value)){
                 if ($classDetails->className === 'Date'){
                     $dateTime = $value->format('Y-m-d');
@@ -345,7 +345,7 @@ class SubMerchantType implements \JsonSerializable
         if(is_array($data) || is_object($data)) {
 			$mapper = \net\authorize\util\Mapper::Instance();
 			foreach($data AS $key => $value) {
-				$classDetails = $mapper->getClass(get_class() , $key);
+				$classDetails = $mapper->getClass(get_class($this) , $key);
 	 
 				if($classDetails !== NULL ) {
 					if ($classDetails->isArray) {

--- a/lib/net/authorize/api/contract/v1/SubscriptionCustomerProfileType.php
+++ b/lib/net/authorize/api/contract/v1/SubscriptionCustomerProfileType.php
@@ -76,7 +76,7 @@ class SubscriptionCustomerProfileType extends CustomerProfileExType implements \
         });
         $mapper = \net\authorize\util\Mapper::Instance();
         foreach($values as $key => $value){
-            $classDetails = $mapper->getClass(get_class() , $key);
+            $classDetails = $mapper->getClass(get_class($this) , $key);
             if (isset($value)){
                 if ($classDetails->className === 'Date'){
                     $dateTime = $value->format('Y-m-d');
@@ -104,7 +104,7 @@ class SubscriptionCustomerProfileType extends CustomerProfileExType implements \
         if(is_array($data) || is_object($data)) {
 			$mapper = \net\authorize\util\Mapper::Instance();
 			foreach($data AS $key => $value) {
-				$classDetails = $mapper->getClass(get_class() , $key);
+				$classDetails = $mapper->getClass(get_class($this) , $key);
 	 
 				if($classDetails !== NULL ) {
 					if ($classDetails->isArray) {

--- a/lib/net/authorize/api/contract/v1/SubscriptionDetailType.php
+++ b/lib/net/authorize/api/contract/v1/SubscriptionDetailType.php
@@ -452,7 +452,7 @@ class SubscriptionDetailType implements \JsonSerializable
         });
         $mapper = \net\authorize\util\Mapper::Instance();
         foreach($values as $key => $value){
-            $classDetails = $mapper->getClass(get_class() , $key);
+            $classDetails = $mapper->getClass(get_class($this) , $key);
             if (isset($value)){
                 if ($classDetails->className === 'Date'){
                     $dateTime = $value->format('Y-m-d');
@@ -480,7 +480,7 @@ class SubscriptionDetailType implements \JsonSerializable
         if(is_array($data) || is_object($data)) {
 			$mapper = \net\authorize\util\Mapper::Instance();
 			foreach($data AS $key => $value) {
-				$classDetails = $mapper->getClass(get_class() , $key);
+				$classDetails = $mapper->getClass(get_class($this) , $key);
 	 
 				if($classDetails !== NULL ) {
 					if ($classDetails->isArray) {

--- a/lib/net/authorize/api/contract/v1/SubscriptionPaymentType.php
+++ b/lib/net/authorize/api/contract/v1/SubscriptionPaymentType.php
@@ -74,7 +74,7 @@ class SubscriptionPaymentType implements \JsonSerializable
         });
         $mapper = \net\authorize\util\Mapper::Instance();
         foreach($values as $key => $value){
-            $classDetails = $mapper->getClass(get_class() , $key);
+            $classDetails = $mapper->getClass(get_class($this) , $key);
             if (isset($value)){
                 if ($classDetails->className === 'Date'){
                     $dateTime = $value->format('Y-m-d');
@@ -102,7 +102,7 @@ class SubscriptionPaymentType implements \JsonSerializable
         if(is_array($data) || is_object($data)) {
 			$mapper = \net\authorize\util\Mapper::Instance();
 			foreach($data AS $key => $value) {
-				$classDetails = $mapper->getClass(get_class() , $key);
+				$classDetails = $mapper->getClass(get_class($this) , $key);
 	 
 				if($classDetails !== NULL ) {
 					if ($classDetails->isArray) {

--- a/lib/net/authorize/api/contract/v1/SubsequentAuthInformationType.php
+++ b/lib/net/authorize/api/contract/v1/SubsequentAuthInformationType.php
@@ -101,7 +101,7 @@ class SubsequentAuthInformationType implements \JsonSerializable
         });
         $mapper = \net\authorize\util\Mapper::Instance();
         foreach($values as $key => $value){
-            $classDetails = $mapper->getClass(get_class() , $key);
+            $classDetails = $mapper->getClass(get_class($this) , $key);
             if (isset($value)){
                 if ($classDetails->className === 'Date'){
                     $dateTime = $value->format('Y-m-d');
@@ -129,7 +129,7 @@ class SubsequentAuthInformationType implements \JsonSerializable
         if(is_array($data) || is_object($data)) {
 			$mapper = \net\authorize\util\Mapper::Instance();
 			foreach($data AS $key => $value) {
-				$classDetails = $mapper->getClass(get_class() , $key);
+				$classDetails = $mapper->getClass(get_class($this) , $key);
 	 
 				if($classDetails !== NULL ) {
 					if ($classDetails->isArray) {

--- a/lib/net/authorize/api/contract/v1/TokenMaskedType.php
+++ b/lib/net/authorize/api/contract/v1/TokenMaskedType.php
@@ -128,7 +128,7 @@ class TokenMaskedType implements \JsonSerializable
         });
         $mapper = \net\authorize\util\Mapper::Instance();
         foreach($values as $key => $value){
-            $classDetails = $mapper->getClass(get_class() , $key);
+            $classDetails = $mapper->getClass(get_class($this) , $key);
             if (isset($value)){
                 if ($classDetails->className === 'Date'){
                     $dateTime = $value->format('Y-m-d');
@@ -156,7 +156,7 @@ class TokenMaskedType implements \JsonSerializable
         if(is_array($data) || is_object($data)) {
 			$mapper = \net\authorize\util\Mapper::Instance();
 			foreach($data AS $key => $value) {
-				$classDetails = $mapper->getClass(get_class() , $key);
+				$classDetails = $mapper->getClass(get_class($this) , $key);
 	 
 				if($classDetails !== NULL ) {
 					if ($classDetails->isArray) {

--- a/lib/net/authorize/api/contract/v1/TransRetailInfoType.php
+++ b/lib/net/authorize/api/contract/v1/TransRetailInfoType.php
@@ -128,7 +128,7 @@ class TransRetailInfoType implements \JsonSerializable
         });
         $mapper = \net\authorize\util\Mapper::Instance();
         foreach($values as $key => $value){
-            $classDetails = $mapper->getClass(get_class() , $key);
+            $classDetails = $mapper->getClass(get_class($this) , $key);
             if (isset($value)){
                 if ($classDetails->className === 'Date'){
                     $dateTime = $value->format('Y-m-d');
@@ -156,7 +156,7 @@ class TransRetailInfoType implements \JsonSerializable
         if(is_array($data) || is_object($data)) {
 			$mapper = \net\authorize\util\Mapper::Instance();
 			foreach($data AS $key => $value) {
-				$classDetails = $mapper->getClass(get_class() , $key);
+				$classDetails = $mapper->getClass(get_class($this) , $key);
 	 
 				if($classDetails !== NULL ) {
 					if ($classDetails->isArray) {

--- a/lib/net/authorize/api/contract/v1/TransactionDetailsType.php
+++ b/lib/net/authorize/api/contract/v1/TransactionDetailsType.php
@@ -1567,7 +1567,7 @@ class TransactionDetailsType implements \JsonSerializable
         });
         $mapper = \net\authorize\util\Mapper::Instance();
         foreach($values as $key => $value){
-            $classDetails = $mapper->getClass(get_class() , $key);
+            $classDetails = $mapper->getClass(get_class($this) , $key);
             if (isset($value)){
                 if ($classDetails->className === 'Date'){
                     $dateTime = $value->format('Y-m-d');
@@ -1595,7 +1595,7 @@ class TransactionDetailsType implements \JsonSerializable
         if(is_array($data) || is_object($data)) {
 			$mapper = \net\authorize\util\Mapper::Instance();
 			foreach($data AS $key => $value) {
-				$classDetails = $mapper->getClass(get_class() , $key);
+				$classDetails = $mapper->getClass(get_class($this) , $key);
 	 
 				if($classDetails !== NULL ) {
 					if ($classDetails->isArray) {

--- a/lib/net/authorize/api/contract/v1/TransactionDetailsType/EmvDetailsAType.php
+++ b/lib/net/authorize/api/contract/v1/TransactionDetailsType/EmvDetailsAType.php
@@ -85,7 +85,7 @@ class EmvDetailsAType implements \JsonSerializable
         });
         $mapper = \net\authorize\util\Mapper::Instance();
         foreach($values as $key => $value){
-            $classDetails = $mapper->getClass(get_class() , $key);
+            $classDetails = $mapper->getClass(get_class($this) , $key);
             if (isset($value)){
                 if ($classDetails->className === 'Date'){
                     $dateTime = $value->format('Y-m-d');
@@ -113,7 +113,7 @@ class EmvDetailsAType implements \JsonSerializable
         if(is_array($data) || is_object($data)) {
 			$mapper = \net\authorize\util\Mapper::Instance();
 			foreach($data AS $key => $value) {
-				$classDetails = $mapper->getClass(get_class() , $key);
+				$classDetails = $mapper->getClass(get_class($this) , $key);
 	 
 				if($classDetails !== NULL ) {
 					if ($classDetails->isArray) {

--- a/lib/net/authorize/api/contract/v1/TransactionDetailsType/EmvDetailsAType/TagAType.php
+++ b/lib/net/authorize/api/contract/v1/TransactionDetailsType/EmvDetailsAType/TagAType.php
@@ -71,7 +71,7 @@ class TagAType implements \JsonSerializable
         });
         $mapper = \net\authorize\util\Mapper::Instance();
         foreach($values as $key => $value){
-            $classDetails = $mapper->getClass(get_class() , $key);
+            $classDetails = $mapper->getClass(get_class($this) , $key);
             if (isset($value)){
                 if ($classDetails->className === 'Date'){
                     $dateTime = $value->format('Y-m-d');
@@ -99,7 +99,7 @@ class TagAType implements \JsonSerializable
         if(is_array($data) || is_object($data)) {
 			$mapper = \net\authorize\util\Mapper::Instance();
 			foreach($data AS $key => $value) {
-				$classDetails = $mapper->getClass(get_class() , $key);
+				$classDetails = $mapper->getClass(get_class($this) , $key);
 	 
 				if($classDetails !== NULL ) {
 					if ($classDetails->isArray) {

--- a/lib/net/authorize/api/contract/v1/TransactionListSortingType.php
+++ b/lib/net/authorize/api/contract/v1/TransactionListSortingType.php
@@ -74,7 +74,7 @@ class TransactionListSortingType implements \JsonSerializable
         });
         $mapper = \net\authorize\util\Mapper::Instance();
         foreach($values as $key => $value){
-            $classDetails = $mapper->getClass(get_class() , $key);
+            $classDetails = $mapper->getClass(get_class($this) , $key);
             if (isset($value)){
                 if ($classDetails->className === 'Date'){
                     $dateTime = $value->format('Y-m-d');
@@ -102,7 +102,7 @@ class TransactionListSortingType implements \JsonSerializable
         if(is_array($data) || is_object($data)) {
 			$mapper = \net\authorize\util\Mapper::Instance();
 			foreach($data AS $key => $value) {
-				$classDetails = $mapper->getClass(get_class() , $key);
+				$classDetails = $mapper->getClass(get_class($this) , $key);
 	 
 				if($classDetails !== NULL ) {
 					if ($classDetails->isArray) {

--- a/lib/net/authorize/api/contract/v1/TransactionRequestType.php
+++ b/lib/net/authorize/api/contract/v1/TransactionRequestType.php
@@ -1125,7 +1125,7 @@ class TransactionRequestType implements \JsonSerializable
         });
         $mapper = \net\authorize\util\Mapper::Instance();
         foreach($values as $key => $value){
-            $classDetails = $mapper->getClass(get_class() , $key);
+            $classDetails = $mapper->getClass(get_class($this) , $key);
             if (isset($value)){
                 if ($classDetails->className === 'Date'){
                     $dateTime = $value->format('Y-m-d');
@@ -1153,7 +1153,7 @@ class TransactionRequestType implements \JsonSerializable
         if(is_array($data) || is_object($data)) {
 			$mapper = \net\authorize\util\Mapper::Instance();
 			foreach($data AS $key => $value) {
-				$classDetails = $mapper->getClass(get_class() , $key);
+				$classDetails = $mapper->getClass(get_class($this) , $key);
 	 
 				if($classDetails !== NULL ) {
 					if ($classDetails->isArray) {

--- a/lib/net/authorize/api/contract/v1/TransactionRequestType/UserFieldsAType.php
+++ b/lib/net/authorize/api/contract/v1/TransactionRequestType/UserFieldsAType.php
@@ -78,7 +78,7 @@ class UserFieldsAType implements \JsonSerializable
         });
         $mapper = \net\authorize\util\Mapper::Instance();
         foreach($values as $key => $value){
-            $classDetails = $mapper->getClass(get_class() , $key);
+            $classDetails = $mapper->getClass(get_class($this) , $key);
             if (isset($value)){
                 if ($classDetails->className === 'Date'){
                     $dateTime = $value->format('Y-m-d');
@@ -106,7 +106,7 @@ class UserFieldsAType implements \JsonSerializable
         if(is_array($data) || is_object($data)) {
 			$mapper = \net\authorize\util\Mapper::Instance();
 			foreach($data AS $key => $value) {
-				$classDetails = $mapper->getClass(get_class() , $key);
+				$classDetails = $mapper->getClass(get_class($this) , $key);
 	 
 				if($classDetails !== NULL ) {
 					if ($classDetails->isArray) {

--- a/lib/net/authorize/api/contract/v1/TransactionResponseType.php
+++ b/lib/net/authorize/api/contract/v1/TransactionResponseType.php
@@ -863,7 +863,7 @@ class TransactionResponseType implements \JsonSerializable
         });
         $mapper = \net\authorize\util\Mapper::Instance();
         foreach($values as $key => $value){
-            $classDetails = $mapper->getClass(get_class() , $key);
+            $classDetails = $mapper->getClass(get_class($this) , $key);
             if (isset($value)){
                 if ($classDetails->className === 'Date'){
                     $dateTime = $value->format('Y-m-d');
@@ -891,7 +891,7 @@ class TransactionResponseType implements \JsonSerializable
         if(is_array($data) || is_object($data)) {
 			$mapper = \net\authorize\util\Mapper::Instance();
 			foreach($data AS $key => $value) {
-				$classDetails = $mapper->getClass(get_class() , $key);
+				$classDetails = $mapper->getClass(get_class($this) , $key);
 	 
 				if($classDetails !== NULL ) {
 					if ($classDetails->isArray) {

--- a/lib/net/authorize/api/contract/v1/TransactionResponseType/EmvResponseAType.php
+++ b/lib/net/authorize/api/contract/v1/TransactionResponseType/EmvResponseAType.php
@@ -105,7 +105,7 @@ class EmvResponseAType implements \JsonSerializable
         });
         $mapper = \net\authorize\util\Mapper::Instance();
         foreach($values as $key => $value){
-            $classDetails = $mapper->getClass(get_class() , $key);
+            $classDetails = $mapper->getClass(get_class($this) , $key);
             if (isset($value)){
                 if ($classDetails->className === 'Date'){
                     $dateTime = $value->format('Y-m-d');
@@ -133,7 +133,7 @@ class EmvResponseAType implements \JsonSerializable
         if(is_array($data) || is_object($data)) {
 			$mapper = \net\authorize\util\Mapper::Instance();
 			foreach($data AS $key => $value) {
-				$classDetails = $mapper->getClass(get_class() , $key);
+				$classDetails = $mapper->getClass(get_class($this) , $key);
 	 
 				if($classDetails !== NULL ) {
 					if ($classDetails->isArray) {

--- a/lib/net/authorize/api/contract/v1/TransactionResponseType/EmvResponseAType/TagsAType.php
+++ b/lib/net/authorize/api/contract/v1/TransactionResponseType/EmvResponseAType/TagsAType.php
@@ -78,7 +78,7 @@ class TagsAType implements \JsonSerializable
         });
         $mapper = \net\authorize\util\Mapper::Instance();
         foreach($values as $key => $value){
-            $classDetails = $mapper->getClass(get_class() , $key);
+            $classDetails = $mapper->getClass(get_class($this) , $key);
             if (isset($value)){
                 if ($classDetails->className === 'Date'){
                     $dateTime = $value->format('Y-m-d');
@@ -106,7 +106,7 @@ class TagsAType implements \JsonSerializable
         if(is_array($data) || is_object($data)) {
 			$mapper = \net\authorize\util\Mapper::Instance();
 			foreach($data AS $key => $value) {
-				$classDetails = $mapper->getClass(get_class() , $key);
+				$classDetails = $mapper->getClass(get_class($this) , $key);
 	 
 				if($classDetails !== NULL ) {
 					if ($classDetails->isArray) {

--- a/lib/net/authorize/api/contract/v1/TransactionResponseType/ErrorsAType.php
+++ b/lib/net/authorize/api/contract/v1/TransactionResponseType/ErrorsAType.php
@@ -85,7 +85,7 @@ class ErrorsAType implements \JsonSerializable
         });
         $mapper = \net\authorize\util\Mapper::Instance();
         foreach($values as $key => $value){
-            $classDetails = $mapper->getClass(get_class() , $key);
+            $classDetails = $mapper->getClass(get_class($this) , $key);
             if (isset($value)){
                 if ($classDetails->className === 'Date'){
                     $dateTime = $value->format('Y-m-d');
@@ -113,7 +113,7 @@ class ErrorsAType implements \JsonSerializable
         if(is_array($data) || is_object($data)) {
 			$mapper = \net\authorize\util\Mapper::Instance();
 			foreach($data AS $key => $value) {
-				$classDetails = $mapper->getClass(get_class() , $key);
+				$classDetails = $mapper->getClass(get_class($this) , $key);
 	 
 				if($classDetails !== NULL ) {
 					if ($classDetails->isArray) {

--- a/lib/net/authorize/api/contract/v1/TransactionResponseType/ErrorsAType/ErrorAType.php
+++ b/lib/net/authorize/api/contract/v1/TransactionResponseType/ErrorsAType/ErrorAType.php
@@ -71,7 +71,7 @@ class ErrorAType implements \JsonSerializable
         });
         $mapper = \net\authorize\util\Mapper::Instance();
         foreach($values as $key => $value){
-            $classDetails = $mapper->getClass(get_class() , $key);
+            $classDetails = $mapper->getClass(get_class($this) , $key);
             if (isset($value)){
                 if ($classDetails->className === 'Date'){
                     $dateTime = $value->format('Y-m-d');
@@ -99,7 +99,7 @@ class ErrorAType implements \JsonSerializable
         if(is_array($data) || is_object($data)) {
 			$mapper = \net\authorize\util\Mapper::Instance();
 			foreach($data AS $key => $value) {
-				$classDetails = $mapper->getClass(get_class() , $key);
+				$classDetails = $mapper->getClass(get_class($this) , $key);
 	 
 				if($classDetails !== NULL ) {
 					if ($classDetails->isArray) {

--- a/lib/net/authorize/api/contract/v1/TransactionResponseType/MessagesAType.php
+++ b/lib/net/authorize/api/contract/v1/TransactionResponseType/MessagesAType.php
@@ -85,7 +85,7 @@ class MessagesAType implements \JsonSerializable
         });
         $mapper = \net\authorize\util\Mapper::Instance();
         foreach($values as $key => $value){
-            $classDetails = $mapper->getClass(get_class() , $key);
+            $classDetails = $mapper->getClass(get_class($this) , $key);
             if (isset($value)){
                 if ($classDetails->className === 'Date'){
                     $dateTime = $value->format('Y-m-d');
@@ -113,7 +113,7 @@ class MessagesAType implements \JsonSerializable
         if(is_array($data) || is_object($data)) {
 			$mapper = \net\authorize\util\Mapper::Instance();
 			foreach($data AS $key => $value) {
-				$classDetails = $mapper->getClass(get_class() , $key);
+				$classDetails = $mapper->getClass(get_class($this) , $key);
 	 
 				if($classDetails !== NULL ) {
 					if ($classDetails->isArray) {

--- a/lib/net/authorize/api/contract/v1/TransactionResponseType/MessagesAType/MessageAType.php
+++ b/lib/net/authorize/api/contract/v1/TransactionResponseType/MessagesAType/MessageAType.php
@@ -71,7 +71,7 @@ class MessageAType implements \JsonSerializable
         });
         $mapper = \net\authorize\util\Mapper::Instance();
         foreach($values as $key => $value){
-            $classDetails = $mapper->getClass(get_class() , $key);
+            $classDetails = $mapper->getClass(get_class($this) , $key);
             if (isset($value)){
                 if ($classDetails->className === 'Date'){
                     $dateTime = $value->format('Y-m-d');
@@ -99,7 +99,7 @@ class MessageAType implements \JsonSerializable
         if(is_array($data) || is_object($data)) {
 			$mapper = \net\authorize\util\Mapper::Instance();
 			foreach($data AS $key => $value) {
-				$classDetails = $mapper->getClass(get_class() , $key);
+				$classDetails = $mapper->getClass(get_class($this) , $key);
 	 
 				if($classDetails !== NULL ) {
 					if ($classDetails->isArray) {

--- a/lib/net/authorize/api/contract/v1/TransactionResponseType/PrePaidCardAType.php
+++ b/lib/net/authorize/api/contract/v1/TransactionResponseType/PrePaidCardAType.php
@@ -98,7 +98,7 @@ class PrePaidCardAType implements \JsonSerializable
         });
         $mapper = \net\authorize\util\Mapper::Instance();
         foreach($values as $key => $value){
-            $classDetails = $mapper->getClass(get_class() , $key);
+            $classDetails = $mapper->getClass(get_class($this) , $key);
             if (isset($value)){
                 if ($classDetails->className === 'Date'){
                     $dateTime = $value->format('Y-m-d');
@@ -126,7 +126,7 @@ class PrePaidCardAType implements \JsonSerializable
         if(is_array($data) || is_object($data)) {
 			$mapper = \net\authorize\util\Mapper::Instance();
 			foreach($data AS $key => $value) {
-				$classDetails = $mapper->getClass(get_class() , $key);
+				$classDetails = $mapper->getClass(get_class($this) , $key);
 	 
 				if($classDetails !== NULL ) {
 					if ($classDetails->isArray) {

--- a/lib/net/authorize/api/contract/v1/TransactionResponseType/SecureAcceptanceAType.php
+++ b/lib/net/authorize/api/contract/v1/TransactionResponseType/SecureAcceptanceAType.php
@@ -98,7 +98,7 @@ class SecureAcceptanceAType implements \JsonSerializable
         });
         $mapper = \net\authorize\util\Mapper::Instance();
         foreach($values as $key => $value){
-            $classDetails = $mapper->getClass(get_class() , $key);
+            $classDetails = $mapper->getClass(get_class($this) , $key);
             if (isset($value)){
                 if ($classDetails->className === 'Date'){
                     $dateTime = $value->format('Y-m-d');
@@ -126,7 +126,7 @@ class SecureAcceptanceAType implements \JsonSerializable
         if(is_array($data) || is_object($data)) {
 			$mapper = \net\authorize\util\Mapper::Instance();
 			foreach($data AS $key => $value) {
-				$classDetails = $mapper->getClass(get_class() , $key);
+				$classDetails = $mapper->getClass(get_class($this) , $key);
 	 
 				if($classDetails !== NULL ) {
 					if ($classDetails->isArray) {

--- a/lib/net/authorize/api/contract/v1/TransactionResponseType/SplitTenderPaymentsAType.php
+++ b/lib/net/authorize/api/contract/v1/TransactionResponseType/SplitTenderPaymentsAType.php
@@ -85,7 +85,7 @@ class SplitTenderPaymentsAType implements \JsonSerializable
         });
         $mapper = \net\authorize\util\Mapper::Instance();
         foreach($values as $key => $value){
-            $classDetails = $mapper->getClass(get_class() , $key);
+            $classDetails = $mapper->getClass(get_class($this) , $key);
             if (isset($value)){
                 if ($classDetails->className === 'Date'){
                     $dateTime = $value->format('Y-m-d');
@@ -113,7 +113,7 @@ class SplitTenderPaymentsAType implements \JsonSerializable
         if(is_array($data) || is_object($data)) {
 			$mapper = \net\authorize\util\Mapper::Instance();
 			foreach($data AS $key => $value) {
-				$classDetails = $mapper->getClass(get_class() , $key);
+				$classDetails = $mapper->getClass(get_class($this) , $key);
 	 
 				if($classDetails !== NULL ) {
 					if ($classDetails->isArray) {

--- a/lib/net/authorize/api/contract/v1/TransactionResponseType/SplitTenderPaymentsAType/SplitTenderPaymentAType.php
+++ b/lib/net/authorize/api/contract/v1/TransactionResponseType/SplitTenderPaymentsAType/SplitTenderPaymentAType.php
@@ -260,7 +260,7 @@ class SplitTenderPaymentAType implements \JsonSerializable
         });
         $mapper = \net\authorize\util\Mapper::Instance();
         foreach($values as $key => $value){
-            $classDetails = $mapper->getClass(get_class() , $key);
+            $classDetails = $mapper->getClass(get_class($this) , $key);
             if (isset($value)){
                 if ($classDetails->className === 'Date'){
                     $dateTime = $value->format('Y-m-d');
@@ -288,7 +288,7 @@ class SplitTenderPaymentAType implements \JsonSerializable
         if(is_array($data) || is_object($data)) {
 			$mapper = \net\authorize\util\Mapper::Instance();
 			foreach($data AS $key => $value) {
-				$classDetails = $mapper->getClass(get_class() , $key);
+				$classDetails = $mapper->getClass(get_class($this) , $key);
 	 
 				if($classDetails !== NULL ) {
 					if ($classDetails->isArray) {

--- a/lib/net/authorize/api/contract/v1/TransactionResponseType/UserFieldsAType.php
+++ b/lib/net/authorize/api/contract/v1/TransactionResponseType/UserFieldsAType.php
@@ -78,7 +78,7 @@ class UserFieldsAType implements \JsonSerializable
         });
         $mapper = \net\authorize\util\Mapper::Instance();
         foreach($values as $key => $value){
-            $classDetails = $mapper->getClass(get_class() , $key);
+            $classDetails = $mapper->getClass(get_class($this) , $key);
             if (isset($value)){
                 if ($classDetails->className === 'Date'){
                     $dateTime = $value->format('Y-m-d');
@@ -106,7 +106,7 @@ class UserFieldsAType implements \JsonSerializable
         if(is_array($data) || is_object($data)) {
 			$mapper = \net\authorize\util\Mapper::Instance();
 			foreach($data AS $key => $value) {
-				$classDetails = $mapper->getClass(get_class() , $key);
+				$classDetails = $mapper->getClass(get_class($this) , $key);
 	 
 				if($classDetails !== NULL ) {
 					if ($classDetails->isArray) {

--- a/lib/net/authorize/api/contract/v1/TransactionSummaryType.php
+++ b/lib/net/authorize/api/contract/v1/TransactionSummaryType.php
@@ -479,7 +479,7 @@ class TransactionSummaryType implements \JsonSerializable
         });
         $mapper = \net\authorize\util\Mapper::Instance();
         foreach($values as $key => $value){
-            $classDetails = $mapper->getClass(get_class() , $key);
+            $classDetails = $mapper->getClass(get_class($this) , $key);
             if (isset($value)){
                 if ($classDetails->className === 'Date'){
                     $dateTime = $value->format('Y-m-d');
@@ -507,7 +507,7 @@ class TransactionSummaryType implements \JsonSerializable
         if(is_array($data) || is_object($data)) {
 			$mapper = \net\authorize\util\Mapper::Instance();
 			foreach($data AS $key => $value) {
-				$classDetails = $mapper->getClass(get_class() , $key);
+				$classDetails = $mapper->getClass(get_class($this) , $key);
 	 
 				if($classDetails !== NULL ) {
 					if ($classDetails->isArray) {

--- a/lib/net/authorize/api/contract/v1/UpdateCustomerPaymentProfileRequest.php
+++ b/lib/net/authorize/api/contract/v1/UpdateCustomerPaymentProfileRequest.php
@@ -100,7 +100,7 @@ class UpdateCustomerPaymentProfileRequest extends ANetApiRequestType
         });
         $mapper = \net\authorize\util\Mapper::Instance();
         foreach($values as $key => $value){
-            $classDetails = $mapper->getClass(get_class() , $key);
+            $classDetails = $mapper->getClass(get_class($this) , $key);
             if (isset($value)){
                 if ($classDetails->className === 'Date'){
                     $dateTime = $value->format('Y-m-d');

--- a/lib/net/authorize/api/contract/v1/UpdateCustomerPaymentProfileResponse.php
+++ b/lib/net/authorize/api/contract/v1/UpdateCustomerPaymentProfileResponse.php
@@ -42,7 +42,7 @@ class UpdateCustomerPaymentProfileResponse extends ANetApiResponseType
         if(is_array($data) || is_object($data)) {
 			$mapper = \net\authorize\util\Mapper::Instance();
 			foreach($data AS $key => $value) {
-				$classDetails = $mapper->getClass(get_class() , $key);
+				$classDetails = $mapper->getClass(get_class($this) , $key);
 	 
 				if($classDetails !== NULL ) {
 					if ($classDetails->isArray) {

--- a/lib/net/authorize/api/contract/v1/UpdateCustomerProfileRequest.php
+++ b/lib/net/authorize/api/contract/v1/UpdateCustomerProfileRequest.php
@@ -44,7 +44,7 @@ class UpdateCustomerProfileRequest extends ANetApiRequestType
         });
         $mapper = \net\authorize\util\Mapper::Instance();
         foreach($values as $key => $value){
-            $classDetails = $mapper->getClass(get_class() , $key);
+            $classDetails = $mapper->getClass(get_class($this) , $key);
             if (isset($value)){
                 if ($classDetails->className === 'Date'){
                     $dateTime = $value->format('Y-m-d');

--- a/lib/net/authorize/api/contract/v1/UpdateCustomerProfileResponse.php
+++ b/lib/net/authorize/api/contract/v1/UpdateCustomerProfileResponse.php
@@ -15,7 +15,7 @@ class UpdateCustomerProfileResponse extends ANetApiResponseType
         if(is_array($data) || is_object($data)) {
 			$mapper = \net\authorize\util\Mapper::Instance();
 			foreach($data AS $key => $value) {
-				$classDetails = $mapper->getClass(get_class() , $key);
+				$classDetails = $mapper->getClass(get_class($this) , $key);
 	 
 				if($classDetails !== NULL ) {
 					if ($classDetails->isArray) {

--- a/lib/net/authorize/api/contract/v1/UpdateCustomerShippingAddressRequest.php
+++ b/lib/net/authorize/api/contract/v1/UpdateCustomerShippingAddressRequest.php
@@ -98,7 +98,7 @@ class UpdateCustomerShippingAddressRequest extends ANetApiRequestType
         });
         $mapper = \net\authorize\util\Mapper::Instance();
         foreach($values as $key => $value){
-            $classDetails = $mapper->getClass(get_class() , $key);
+            $classDetails = $mapper->getClass(get_class($this) , $key);
             if (isset($value)){
                 if ($classDetails->className === 'Date'){
                     $dateTime = $value->format('Y-m-d');

--- a/lib/net/authorize/api/contract/v1/UpdateCustomerShippingAddressResponse.php
+++ b/lib/net/authorize/api/contract/v1/UpdateCustomerShippingAddressResponse.php
@@ -15,7 +15,7 @@ class UpdateCustomerShippingAddressResponse extends ANetApiResponseType
         if(is_array($data) || is_object($data)) {
 			$mapper = \net\authorize\util\Mapper::Instance();
 			foreach($data AS $key => $value) {
-				$classDetails = $mapper->getClass(get_class() , $key);
+				$classDetails = $mapper->getClass(get_class($this) , $key);
 	 
 				if($classDetails !== NULL ) {
 					if ($classDetails->isArray) {

--- a/lib/net/authorize/api/contract/v1/UpdateHeldTransactionRequest.php
+++ b/lib/net/authorize/api/contract/v1/UpdateHeldTransactionRequest.php
@@ -46,7 +46,7 @@ class UpdateHeldTransactionRequest extends ANetApiRequestType
         });
         $mapper = \net\authorize\util\Mapper::Instance();
         foreach($values as $key => $value){
-            $classDetails = $mapper->getClass(get_class() , $key);
+            $classDetails = $mapper->getClass(get_class($this) , $key);
             if (isset($value)){
                 if ($classDetails->className === 'Date'){
                     $dateTime = $value->format('Y-m-d');

--- a/lib/net/authorize/api/contract/v1/UpdateHeldTransactionResponse.php
+++ b/lib/net/authorize/api/contract/v1/UpdateHeldTransactionResponse.php
@@ -44,7 +44,7 @@ class UpdateHeldTransactionResponse extends ANetApiResponseType
         if(is_array($data) || is_object($data)) {
 			$mapper = \net\authorize\util\Mapper::Instance();
 			foreach($data AS $key => $value) {
-				$classDetails = $mapper->getClass(get_class() , $key);
+				$classDetails = $mapper->getClass(get_class($this) , $key);
 	 
 				if($classDetails !== NULL ) {
 					if ($classDetails->isArray) {

--- a/lib/net/authorize/api/contract/v1/UpdateMerchantDetailsRequest.php
+++ b/lib/net/authorize/api/contract/v1/UpdateMerchantDetailsRequest.php
@@ -44,7 +44,7 @@ class UpdateMerchantDetailsRequest extends ANetApiRequestType
         });
         $mapper = \net\authorize\util\Mapper::Instance();
         foreach($values as $key => $value){
-            $classDetails = $mapper->getClass(get_class() , $key);
+            $classDetails = $mapper->getClass(get_class($this) , $key);
             if (isset($value)){
                 if ($classDetails->className === 'Date'){
                     $dateTime = $value->format('Y-m-d');

--- a/lib/net/authorize/api/contract/v1/UpdateMerchantDetailsResponse.php
+++ b/lib/net/authorize/api/contract/v1/UpdateMerchantDetailsResponse.php
@@ -15,7 +15,7 @@ class UpdateMerchantDetailsResponse extends ANetApiResponseType
         if(is_array($data) || is_object($data)) {
 			$mapper = \net\authorize\util\Mapper::Instance();
 			foreach($data AS $key => $value) {
-				$classDetails = $mapper->getClass(get_class() , $key);
+				$classDetails = $mapper->getClass(get_class($this) , $key);
 	 
 				if($classDetails !== NULL ) {
 					if ($classDetails->isArray) {

--- a/lib/net/authorize/api/contract/v1/UpdateSplitTenderGroupRequest.php
+++ b/lib/net/authorize/api/contract/v1/UpdateSplitTenderGroupRequest.php
@@ -71,7 +71,7 @@ class UpdateSplitTenderGroupRequest extends ANetApiRequestType
         });
         $mapper = \net\authorize\util\Mapper::Instance();
         foreach($values as $key => $value){
-            $classDetails = $mapper->getClass(get_class() , $key);
+            $classDetails = $mapper->getClass(get_class($this) , $key);
             if (isset($value)){
                 if ($classDetails->className === 'Date'){
                     $dateTime = $value->format('Y-m-d');

--- a/lib/net/authorize/api/contract/v1/UpdateSplitTenderGroupResponse.php
+++ b/lib/net/authorize/api/contract/v1/UpdateSplitTenderGroupResponse.php
@@ -15,7 +15,7 @@ class UpdateSplitTenderGroupResponse extends ANetApiResponseType
         if(is_array($data) || is_object($data)) {
 			$mapper = \net\authorize\util\Mapper::Instance();
 			foreach($data AS $key => $value) {
-				$classDetails = $mapper->getClass(get_class() , $key);
+				$classDetails = $mapper->getClass(get_class($this) , $key);
 	 
 				if($classDetails !== NULL ) {
 					if ($classDetails->isArray) {

--- a/lib/net/authorize/api/contract/v1/UserFieldType.php
+++ b/lib/net/authorize/api/contract/v1/UserFieldType.php
@@ -74,7 +74,7 @@ class UserFieldType implements \JsonSerializable
         });
         $mapper = \net\authorize\util\Mapper::Instance();
         foreach($values as $key => $value){
-            $classDetails = $mapper->getClass(get_class() , $key);
+            $classDetails = $mapper->getClass(get_class($this) , $key);
             if (isset($value)){
                 if ($classDetails->className === 'Date'){
                     $dateTime = $value->format('Y-m-d');
@@ -102,7 +102,7 @@ class UserFieldType implements \JsonSerializable
         if(is_array($data) || is_object($data)) {
 			$mapper = \net\authorize\util\Mapper::Instance();
 			foreach($data AS $key => $value) {
-				$classDetails = $mapper->getClass(get_class() , $key);
+				$classDetails = $mapper->getClass(get_class($this) , $key);
 	 
 				if($classDetails !== NULL ) {
 					if ($classDetails->isArray) {

--- a/lib/net/authorize/api/contract/v1/ValidateCustomerPaymentProfileRequest.php
+++ b/lib/net/authorize/api/contract/v1/ValidateCustomerPaymentProfileRequest.php
@@ -152,7 +152,7 @@ class ValidateCustomerPaymentProfileRequest extends ANetApiRequestType
         });
         $mapper = \net\authorize\util\Mapper::Instance();
         foreach($values as $key => $value){
-            $classDetails = $mapper->getClass(get_class() , $key);
+            $classDetails = $mapper->getClass(get_class($this) , $key);
             if (isset($value)){
                 if ($classDetails->className === 'Date'){
                     $dateTime = $value->format('Y-m-d');

--- a/lib/net/authorize/api/contract/v1/ValidateCustomerPaymentProfileResponse.php
+++ b/lib/net/authorize/api/contract/v1/ValidateCustomerPaymentProfileResponse.php
@@ -42,7 +42,7 @@ class ValidateCustomerPaymentProfileResponse extends ANetApiResponseType
         if(is_array($data) || is_object($data)) {
 			$mapper = \net\authorize\util\Mapper::Instance();
 			foreach($data AS $key => $value) {
-				$classDetails = $mapper->getClass(get_class() , $key);
+				$classDetails = $mapper->getClass(get_class($this) , $key);
 	 
 				if($classDetails !== NULL ) {
 					if ($classDetails->isArray) {

--- a/lib/net/authorize/api/contract/v1/WebCheckOutDataType.php
+++ b/lib/net/authorize/api/contract/v1/WebCheckOutDataType.php
@@ -128,7 +128,7 @@ class WebCheckOutDataType implements \JsonSerializable
         });
         $mapper = \net\authorize\util\Mapper::Instance();
         foreach($values as $key => $value){
-            $classDetails = $mapper->getClass(get_class() , $key);
+            $classDetails = $mapper->getClass(get_class($this) , $key);
             if (isset($value)){
                 if ($classDetails->className === 'Date'){
                     $dateTime = $value->format('Y-m-d');
@@ -156,7 +156,7 @@ class WebCheckOutDataType implements \JsonSerializable
         if(is_array($data) || is_object($data)) {
 			$mapper = \net\authorize\util\Mapper::Instance();
 			foreach($data AS $key => $value) {
-				$classDetails = $mapper->getClass(get_class() , $key);
+				$classDetails = $mapper->getClass(get_class($this) , $key);
 	 
 				if($classDetails !== NULL ) {
 					if ($classDetails->isArray) {

--- a/lib/net/authorize/api/contract/v1/WebCheckOutDataTypeTokenType.php
+++ b/lib/net/authorize/api/contract/v1/WebCheckOutDataTypeTokenType.php
@@ -155,7 +155,7 @@ class WebCheckOutDataTypeTokenType implements \JsonSerializable
         });
         $mapper = \net\authorize\util\Mapper::Instance();
         foreach($values as $key => $value){
-            $classDetails = $mapper->getClass(get_class() , $key);
+            $classDetails = $mapper->getClass(get_class($this) , $key);
             if (isset($value)){
                 if ($classDetails->className === 'Date'){
                     $dateTime = $value->format('Y-m-d');
@@ -183,7 +183,7 @@ class WebCheckOutDataTypeTokenType implements \JsonSerializable
         if(is_array($data) || is_object($data)) {
 			$mapper = \net\authorize\util\Mapper::Instance();
 			foreach($data AS $key => $value) {
-				$classDetails = $mapper->getClass(get_class() , $key);
+				$classDetails = $mapper->getClass(get_class($this) , $key);
 	 
 				if($classDetails !== NULL ) {
 					if ($classDetails->isArray) {

--- a/scripts/appendJsonSerializeCode.txt
+++ b/scripts/appendJsonSerializeCode.txt
@@ -6,7 +6,7 @@
         });
         $mapper = \net\authorize\util\Mapper::Instance();
         foreach($values as $key => $value){
-            $classDetails = $mapper->getClass(get_class() , $key);
+            $classDetails = $mapper->getClass(get_class($this) , $key);
             if (isset($value)){
                 if ($classDetails->className === 'Date'){
                     $dateTime = $value->format('Y-m-d');

--- a/scripts/appendJsonSerializeSubClassCode.txt
+++ b/scripts/appendJsonSerializeSubClassCode.txt
@@ -6,7 +6,7 @@
         });
         $mapper = \net\authorize\util\Mapper::Instance();
         foreach($values as $key => $value){
-            $classDetails = $mapper->getClass(get_class() , $key);
+            $classDetails = $mapper->getClass(get_class($this) , $key);
             if (isset($value)){
                 if ($classDetails->className === 'Date'){
                     $dateTime = $value->format('Y-m-d');

--- a/scripts/appendSetCode.txt
+++ b/scripts/appendSetCode.txt
@@ -4,7 +4,7 @@
         if(is_array($data) || is_object($data)) {
 			$mapper = \net\authorize\util\Mapper::Instance();
 			foreach($data AS $key => $value) {
-				$classDetails = $mapper->getClass(get_class() , $key);
+				$classDetails = $mapper->getClass(get_class($this) , $key);
 	 
 				if($classDetails !== NULL ) {
 					if ($classDetails->isArray) {


### PR DESCRIPTION
PHP 8.3: get_class() and get_parent_class() function calls without arguments deprecated. [Reference](https://php.watch/versions/8.3/get_class-get_parent_class-parameterless-deprecated)

