### PR TITLE
Added (string) typecast to `$prop->getValue()`' call on lib/../util/Log.php:163

### DIFF
--- a/lib/net/authorize/util/Log.php
+++ b/lib/net/authorize/util/Log.php
@@ -32,7 +32,7 @@ class Log
     private $sensitiveStringRegexes = NULL;
     private $logFile = '';
     private $logLevel = ANET_LOG_LEVEL;
-	
+
 	/**
 	* Takes a regex pattern (string) as argument and adds the forward slash delimiter.
 	* Also adds the u flag to enable Unicode mode regex.
@@ -160,7 +160,7 @@ class Log
 			
 			if(strcmp($prop->getName(),$sensitiveField->tagName)==0)
 			{
-				$prop->setValue($obj,preg_replace($inputPattern,$inputReplacement,$prop->getValue($obj)));
+				$prop->setValue($obj,preg_replace($inputPattern,$inputReplacement,(string)$prop->getValue($obj)));
 				return $prop->getValue($obj);
 			}
 		}


### PR DESCRIPTION
This addresses the possible bug still present in 2.0.3 which I discussed in this issue post:

https://github.com/AuthorizeNet/sdk-php/issues/458